### PR TITLE
ci: update workflow to use clouddrove ci user

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,18 +8,20 @@ on:
         type: string
 
 jobs:
-  deploy:
+  create_changelog:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB }}
 
       - name: Update CHANGELOG
         id: changelog
         uses: requarks/changelog-action@v1
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB }}
           excludeTypes: ""
           includeInvalidCommits: false
           tag: ${{ github.ref_name }}
@@ -31,12 +33,16 @@ jobs:
           draft: false
           makeLatest: true
           name: ${{ github.ref_name }}
+          # owner: clouddrove-ci
           body: ${{ steps.changelog.outputs.changes }}
-          token: ${{ github.token }}
+          token: '${{ secrets.GITHUB }}'
 
       - name: Commit CHANGELOG.md
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: ${{ inputs.branch}}
+          commit_user_name: clouddrove-ci # defaults to "github-actions[bot]"
+          commit_user_email: 84795582+clouddrove-ci@users.noreply.github.com # defaults to "41898282+github-actions[bot]@users.noreply.github.com"
+          commit_author: CloudDrove CI <84795582+clouddrove-ci@users.noreply.github.com>
           commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }}'
           file_pattern: CHANGELOG.md


### PR DESCRIPTION
## what
* Updated all token secret to inherit from caller repository. pros: if repository level secrets are created in the caller file so that secrets will inherited and can be used in the shared workflow action.

## why
* User was not able to use the changelog action due to branch protection enabled in the repository.
