### PR TITLE
feat: Updated terraform_workflow for azure

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,6 +27,15 @@ on:
       AZURE_CREDENTIALS:
         required: false
         description: Azure Credentials to install Azure in github runner.
+      AZURE_CLIENT_ID:
+        required: false
+        description: 'Client ID for service principal in Azure.'
+      AZURE_SUBSCRIPTION_ID:
+        required: false
+        description: 'Subscription ID in Azure.'
+      AZURE_TENANT_ID:
+        required: false
+        description: 'Tenant ID of Azure.'
       AWS_ACCESS_KEY_ID:
         required: false
         description: AWS Access Key ID to install AWS CLI.
@@ -46,13 +55,22 @@ on:
         required: false
         description: Terraform cloud token if your backend is terraform cloud.
 
+#Special permissions required for OIDC authentication for Azure
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 jobs:
   terraform-checks:
     name: 'Terraform Validate, Init and Plan'
     runs-on: ubuntu-latest
     env:
-      #  This is needed since we are running terraform with read-only permissions
-      ARM_SKIP_PROVIDER_REGISTRATION: true
+      #  This is needed since we are running terraform with Azure
+        ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
+        ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+        ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
+        ARM_SKIP_PROVIDER_REGISTRATION: true
     outputs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -67,9 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       #  This is needed since we are running terraform with Azure
-        ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
-        ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-        ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
+        ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         ARM_SKIP_PROVIDER_REGISTRATION: true
     outputs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,15 +27,6 @@ on:
       AZURE_CREDENTIALS:
         required: false
         description: Azure Credentials to install Azure in github runner.
-      AZURE_CLIENT_ID:
-        required: false
-        description: 'Client ID for service principal in Azure.'
-      AZURE_SUBSCRIPTION_ID:
-        required: false
-        description: 'Subscription ID in Azure.'
-      AZURE_TENANT_ID:
-        required: false
-        description: 'Tenant ID of Azure.'
       AWS_ACCESS_KEY_ID:
         required: false
         description: AWS Access Key ID to install AWS CLI.
@@ -55,22 +46,13 @@ on:
         required: false
         description: Terraform cloud token if your backend is terraform cloud.
 
-#Special permissions required for OIDC authentication for Azure
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: write
-
 jobs:
   terraform-checks:
     name: 'Terraform Validate, Init and Plan'
     runs-on: ubuntu-latest
     env:
-      #  This is needed since we are running terraform with Azure
-        ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-        ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        ARM_SKIP_PROVIDER_REGISTRATION: true
+      #  This is needed since we are running terraform with read-only permissions
+      ARM_SKIP_PROVIDER_REGISTRATION: true
     outputs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -6,7 +6,6 @@ on:
       replace_tokens:
         required: true
         type: boolean
-        default: true
         description: 'Set true to replace tokens in the terraform files.'
       environmentName:
         required: false
@@ -23,7 +22,6 @@ on:
       working_directory:
         required: true
         type: string
-        default: "terraform/common"
         description: 'Root directory of the terraform where all resources exist.'
       resourceName:
         required: false

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -3,38 +3,10 @@ run-name: 'Terraform workflow'
 on:
   workflow_call:
     inputs:
-      replace_tokens:
-        required: true
-        type: boolean
-        description: 'Set true to replace tokens in the terraform files.'
-      environmentName:
-        required: false
-        type: string
-        default: "dev"
-      region:
-        required: false
-        type: string
-        default: "canadaeast"
       working_directory:
         required: true
         type: string
         description: 'Root directory of the terraform where all resources exist.'
-      resourceName:
-        required: false
-        type: string
-        default: "moduletestref"
-      backend_rg_name:
-        required: false
-        type: string
-        default: "terraform-state-rg"
-      backend_sa_name:
-        required: false
-        type: string
-        default: "tfstatestorageaccountest"
-      backend_container_name:
-        required: false
-        type: string
-        default: "terraform-state"
       provider:
         required: true
         type: string
@@ -153,26 +125,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Update environment variables
-        if: ${{ inputs.replace_tokens == true }}
-        uses: cschleiden/replace-tokens@v1
-        with:
-          tokenPrefix: '#{'
-          tokenSuffix: '}#'
-          files: '["${{ inputs.working_directory }}/main.tf", "${{ inputs.working_directory }}/backend.tf"]'
-        env:
-          RESOURCE_NAME: ${{ inputs.resourceName }}
-          SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-          ENV_NAME: ${{ inputs.environmentName }}
-          REPLACE_REGION: ${{ inputs.region }}
-          CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
-          CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET }}"
-          TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
-          BACKEND_RG_NAME: ${{ inputs.backend_rg_name }}
-          BACKEND_SA_NAME: ${{ inputs.backend_sa_name }}
-          BACKEND_CONTAINER_NAME: ${{ inputs.backend_container_name }}
-
-
       - name: Set environment variables
         run: |
           (
@@ -269,11 +221,6 @@ jobs:
             fi
           fi
 
-      # - name: Publish Terraform Plan
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: tfplan
-      #     path: ${{ inputs.working_directory }}/tfplan
 
       - name: Create String Output
         id: tf-plan-string

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -325,37 +325,37 @@ jobs:
       #       $SLACK_WEBHOOK_URL
 
       - name: Notify Slack
-      if: ${{ always() }}
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-      run: |
-        # Determine the operation type (apply or destroy) using a custom environment variable or flag
-        if [[ "${{ inputs.destroy }}" == "true" ]]; then
-          OPERATION="Destroy"
-        else
-          OPERATION="Apply"
-        fi
-    
-        # Check the job status
-        if [ "${{ job.status }}" == "success" ]; then
-          STATUS="Success ✅"
-          COLOR="good"
-          MESSAGE="Terraform $OPERATION completed successfully."
-        else
-          STATUS="Failed ❌"
-          COLOR="danger"
-          MESSAGE="Terraform $OPERATION failed. Check logs for details."
-        fi
-    
-        # Create the Run URL
-        RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-    
-        # Send the notification to Slack
-        curl -X POST -H 'Content-type: application/json' \
-          --data "$(jq -n --arg color "$COLOR" --arg status "$STATUS" --arg message "$MESSAGE" \
-          --arg operation "$OPERATION" --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_REF_NAME" --arg sha "$GITHUB_SHA" \
-          --arg run_url "$RUN_URL" \
-          '{attachments: [{color: $color, title: ("Terraform " + $operation + ": " + $status), text: $message, fields: [{title: "Operation", value: $operation, short: true}, {title: "Repository", value: $repo, short: true}, {title: "Branch", value: $branch, short: true}, {title: "Commit", value: $sha, short: true}, {title: "Run URL", value: $run_url, short: false}]}]}')" \
-          $SLACK_WEBHOOK_URL
-    
+        if: ${{ always() }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          # Determine the operation type (apply or destroy) using a custom environment variable or flag
+          if [[ "${{ inputs.destroy }}" == "true" ]]; then
+            OPERATION="Destroy"
+          else
+            OPERATION="Apply"
+          fi
+      
+          # Check the job status
+          if [ "${{ job.status }}" == "success" ]; then
+            STATUS="Success ✅"
+            COLOR="good"
+            MESSAGE="Terraform $OPERATION completed successfully."
+          else
+            STATUS="Failed ❌"
+            COLOR="danger"
+            MESSAGE="Terraform $OPERATION failed. Check logs for details."
+          fi
+      
+          # Create the Run URL
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      
+          # Send the notification to Slack
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg color "$COLOR" --arg status "$STATUS" --arg message "$MESSAGE" \
+            --arg operation "$OPERATION" --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_REF_NAME" --arg sha "$GITHUB_SHA" \
+            --arg run_url "$RUN_URL" \
+            '{attachments: [{color: $color, title: ("Terraform " + $operation + ": " + $status), text: $message, fields: [{title: "Operation", value: $operation, short: true}, {title: "Repository", value: $repo, short: true}, {title: "Branch", value: $branch, short: true}, {title: "Commit", value: $sha, short: true}, {title: "Run URL", value: $run_url, short: false}]}]}')" \
+            $SLACK_WEBHOOK_URL
+      
 ...

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -73,7 +73,7 @@ on:
       minimum-approvals:
         required: false
         type: number
-        default: 1
+        default: 0
         description: 'Minimum approvals required to accept the plan'
       token_format:
         required: false

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -300,27 +300,62 @@ jobs:
            terraform destroy -auto-approve
           fi
 
+      # - name: Notify Slack
+      #   if: ${{ always() }}
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      #   run: |
+      #     if [ "${{ job.status }}" == "success" ]; then
+      #       STATUS="Success ✅"
+      #       COLOR="good"
+      #       MESSAGE="Terraform deployment completed successfully."
+      #     else
+      #       STATUS="Failed ❌"
+      #       COLOR="danger"
+      #       MESSAGE="Terraform deployment failed. Check logs for details."
+      #     fi
+
+      #     RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      #     curl -X POST -H 'Content-type: application/json' \
+      #       --data "$(jq -n --arg color "$COLOR" --arg status "$STATUS" --arg message "$MESSAGE" \
+      #       --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_REF_NAME" --arg sha "$GITHUB_SHA" \
+      #       --arg run_url "$RUN_URL" \
+      #       '{attachments: [{color: $color, title: ("Terraform Deployment: " + $status), text: $message, fields: [{title: "Repository", value: $repo, short: true}, {title: "Branch", value: $branch, short: true}, {title: "Commit", value: $sha, short: true}, {title: "Run URL", value: $run_url, short: false}]}]}')" \
+      #       $SLACK_WEBHOOK_URL
+
       - name: Notify Slack
-        if: ${{ always() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-        run: |
-          if [ "${{ job.status }}" == "success" ]; then
-            STATUS="Success ✅"
-            COLOR="good"
-            MESSAGE="Terraform deployment completed successfully."
-          else
-            STATUS="Failed ❌"
-            COLOR="danger"
-            MESSAGE="Terraform deployment failed. Check logs for details."
-          fi
-
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-          curl -X POST -H 'Content-type: application/json' \
-            --data "$(jq -n --arg color "$COLOR" --arg status "$STATUS" --arg message "$MESSAGE" \
-            --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_REF_NAME" --arg sha "$GITHUB_SHA" \
-            --arg run_url "$RUN_URL" \
-            '{attachments: [{color: $color, title: ("Terraform Deployment: " + $status), text: $message, fields: [{title: "Repository", value: $repo, short: true}, {title: "Branch", value: $branch, short: true}, {title: "Commit", value: $sha, short: true}, {title: "Run URL", value: $run_url, short: false}]}]}')" \
-            $SLACK_WEBHOOK_URL
+      if: ${{ always() }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      run: |
+        # Determine the operation type (apply or destroy) using a custom environment variable or flag
+        if [[ "${{ inputs.destroy }}" == "true" ]]; then
+          OPERATION="Destroy"
+        else
+          OPERATION="Apply"
+        fi
+    
+        # Check the job status
+        if [ "${{ job.status }}" == "success" ]; then
+          STATUS="Success ✅"
+          COLOR="good"
+          MESSAGE="Terraform $OPERATION completed successfully."
+        else
+          STATUS="Failed ❌"
+          COLOR="danger"
+          MESSAGE="Terraform $OPERATION failed. Check logs for details."
+        fi
+    
+        # Create the Run URL
+        RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    
+        # Send the notification to Slack
+        curl -X POST -H 'Content-type: application/json' \
+          --data "$(jq -n --arg color "$COLOR" --arg status "$STATUS" --arg message "$MESSAGE" \
+          --arg operation "$OPERATION" --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_REF_NAME" --arg sha "$GITHUB_SHA" \
+          --arg run_url "$RUN_URL" \
+          '{attachments: [{color: $color, title: ("Terraform " + $operation + ": " + $status), text: $message, fields: [{title: "Operation", value: $operation, short: true}, {title: "Repository", value: $repo, short: true}, {title: "Branch", value: $branch, short: true}, {title: "Commit", value: $sha, short: true}, {title: "Run URL", value: $run_url, short: false}]}]}')" \
+          $SLACK_WEBHOOK_URL
+    
 ...

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -78,9 +78,10 @@ on:
         description: 'Subscription ID in Azure.'
       AZURE_TENANT_ID:
         required: false
-      SUBSCRIPTION_ID:
+        description: 'Tenant ID in Azure.' 
+      AZURE_CLIENT_SECRET:
         required: false
-        description: 'Subscription ID of Azure.'
+        description: 'Client Secret for the Azure app registration.'
       AWS_ACCESS_KEY_ID:
         required: false
         description: 'AWS Access Key ID to install AWS CLI.'
@@ -179,10 +180,10 @@ jobs:
 
       - name: terraform init
         run: |
-           export ARM_CLIENT_ID="${{ secrets.CLIENT_ID }}"
-           export ARM_CLIENT_SECRET="${{ secrets.CLIENT_SECRET }}"
-           export ARM_TENANT_ID="${{ secrets.TENANT_ID }}"
-           export ARM_SUBSCRIPTION_ID="${{ secrets.SUBSCRIPTION_ID }}"
+           export ARM_CLIENT_ID="${{ secrets.AZURE_CLIENT_ID }}"
+           export ARM_CLIENT_SECRET="${{ secrets.AZURE_CLIENT_SECRET }}"
+           export ARM_TENANT_ID="${{ secrets.AZURE_TENANT_ID }}"
+           export ARM_SUBSCRIPTION_ID="${{ secrets.AZURE_SUBSCRIPTION_ID }}"
            cd ${{ inputs.working_directory }}
            terraform init
 
@@ -198,10 +199,10 @@ jobs:
         run: |
           export exitcode=0
           cd ${{ inputs.working_directory }}
-          export ARM_CLIENT_ID="${{ secrets.CLIENT_ID }}"
-          export ARM_CLIENT_SECRET="${{ secrets.CLIENT_SECRET }}"
-          export ARM_TENANT_ID="${{ secrets.TENANT_ID }}"
-          export ARM_SUBSCRIPTION_ID="${{ secrets.SUBSCRIPTION_ID }}"
+          export ARM_CLIENT_ID="${{ secrets.AZURE_CLIENT_ID }}"
+          export ARM_CLIENT_SECRET="${{ secrets.AZURE_CLIENT_SECRET }}"
+          export ARM_TENANT_ID="${{ secrets.AZURE_TENANT_ID }}"
+          export ARM_SUBSCRIPTION_ID="${{ secrets.AZURE_SUBSCRIPTION_ID }}"
           if [ "${{ inputs.destroy }}" = true ]; then
             if [ -n "${{ inputs.var_file }}" ]; then
               terraform plan -destroy -out tfplan --var-file=${{ inputs.var_file }}
@@ -250,10 +251,10 @@ jobs:
       - name: terraform apply
         if: ${{ inputs.destroy != true }}
         run: |
-          export ARM_CLIENT_ID="${{ secrets.CLIENT_ID }}"
-          export ARM_CLIENT_SECRET="${{ secrets.CLIENT_SECRET }}"
-          export ARM_TENANT_ID="${{ secrets.TENANT_ID }}"
-          export ARM_SUBSCRIPTION_ID="${{ secrets.SUBSCRIPTION_ID }}"        
+          export ARM_CLIENT_ID="${{ secrets.AZURE_CLIENT_ID }}"
+          export ARM_CLIENT_SECRET="${{ secrets.AZURE_CLIENT_SECRET }}"
+          export ARM_TENANT_ID="${{ secrets.AZURE_TENANT_ID }}"
+          export ARM_SUBSCRIPTION_ID="${{ secrets.AZURE_SUBSCRIPTION_ID }}"        
           if [ -n "${{ inputs.var_file }}" ]; then
            cd ${{ inputs.working_directory }}
            terraform apply -var-file="${{ inputs.var_file }}" -auto-approve
@@ -284,10 +285,10 @@ jobs:
         if: ${{ inputs.destroy == true }}
         id: destroy
         run: |
-          export ARM_CLIENT_ID="${{ secrets.CLIENT_ID }}"
-          export ARM_CLIENT_SECRET="${{ secrets.CLIENT_SECRET }}"
-          export ARM_TENANT_ID="${{ secrets.TENANT_ID }}"
-          export ARM_SUBSCRIPTION_ID="${{ secrets.SUBSCRIPTION_ID }}"
+          export ARM_CLIENT_ID="${{ secrets.AZURE_CLIENT_ID }}"
+          export ARM_CLIENT_SECRET="${{ secrets.AZURE_CLIENT_SECRET }}"
+          export ARM_TENANT_ID="${{ secrets.AZURE_TENANT_ID }}"
+          export ARM_SUBSCRIPTION_ID="${{ secrets.AZURE_SUBSCRIPTION_ID }}"
           if [ -n "${{ inputs.var_file }}" ]; then
            cd ${{ inputs.working_directory }}
            terraform destroy -var-file="${{ inputs.var_file }}" -auto-approve

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -11,10 +11,6 @@ on:
         required: false
         type: string
         default: "dev"
-      terraform_version:
-        required: false
-        type: string
-        default: "1.8.0"
       region:
         required: false
         type: string

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -229,7 +229,6 @@ jobs:
           actions_subcommand: 'fmt'
           path: ${{ inputs.working_directory }}
 
-
       - name: terraform init
         run: |
            export ARM_CLIENT_ID="${{ secrets.AZURE_CLIENT_ID }}"

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -73,8 +73,13 @@ on:
       minimum-approvals:
         required: false
         type: number
-        default: 0
+        default: 1
         description: 'Minimum approvals required to accept the plan'
+      skip_approval:
+        required: false
+        type: boolean
+        default: false
+        description: 'Set true to skip approval step'
       token_format:
         required: false
         type: string
@@ -287,6 +292,7 @@ jobs:
           echo "${delimiter}" >> $GITHUB_OUTPUT
 
       - name: "Accept plan or deny"
+        if: ${{ inputs.skip_approval == false }}
         uses: trstringer/manual-approval@v1
         timeout-minutes: ${{ inputs.timeout }}
         with:

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -3,10 +3,44 @@ run-name: 'Terraform workflow'
 on:
   workflow_call:
     inputs:
+      replace_tokens:
+        required: true
+        type: boolean
+        default: true
+        description: 'Set true to replace tokens in the terraform files.'
+      environmentName:
+        required: false
+        type: string
+        default: "dev"
+      terraform_version:
+        required: false
+        type: string
+        default: "1.8.0"
+      region:
+        required: false
+        type: string
+        default: "canadaeast"
       working_directory:
         required: true
         type: string
+        default: "terraform/common"
         description: 'Root directory of the terraform where all resources exist.'
+      resourceName:
+        required: false
+        type: string
+        default: "moduletestref"
+      backend_rg_name:
+        required: false
+        type: string
+        default: "terraform-state-rg"
+      backend_sa_name:
+        required: false
+        type: string
+        default: "tfstatestorageaccountest"
+      backend_container_name:
+        required: false
+        type: string
+        default: "terraform-state"
       provider:
         required: true
         type: string
@@ -117,8 +151,28 @@ jobs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 
     steps:
-      # - name: Checkout
-      #   uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update environment variables
+        if: ${{ inputs.replace_tokens == true }}
+        uses: cschleiden/replace-tokens@v1
+        with:
+          tokenPrefix: '#{'
+          tokenSuffix: '}#'
+          files: '["${{ inputs.working_directory }}/main.tf", "${{ inputs.working_directory }}/backend.tf"]'
+        env:
+          RESOURCE_NAME: ${{ inputs.resourceName }}
+          SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+          ENV_NAME: ${{ inputs.environmentName }}
+          REPLACE_REGION: ${{ inputs.region }}
+          CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
+          CLIENT_SECRET: "${{ secrets.AZURE_CLIENT_SECRET }}"
+          TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
+          BACKEND_RG_NAME: ${{ inputs.backend_rg_name }}
+          BACKEND_SA_NAME: ${{ inputs.backend_sa_name }}
+          BACKEND_CONTAINER_NAME: ${{ inputs.backend_container_name }}
+
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -117,8 +117,8 @@ jobs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      # - name: Checkout
+      #   uses: actions/checkout@v4
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -72,7 +72,7 @@ on:
         description: 'Timeout for approval step'
       minimum-approvals:
         required: false
-        type: string
+        type: number
         default: 1
         description: 'Minimum approvals required to accept the plan'
       token_format:

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -300,30 +300,6 @@ jobs:
            terraform destroy -auto-approve
           fi
 
-      # - name: Notify Slack
-      #   if: ${{ always() }}
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-      #   run: |
-      #     if [ "${{ job.status }}" == "success" ]; then
-      #       STATUS="Success ✅"
-      #       COLOR="good"
-      #       MESSAGE="Terraform deployment completed successfully."
-      #     else
-      #       STATUS="Failed ❌"
-      #       COLOR="danger"
-      #       MESSAGE="Terraform deployment failed. Check logs for details."
-      #     fi
-
-      #     RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-      #     curl -X POST -H 'Content-type: application/json' \
-      #       --data "$(jq -n --arg color "$COLOR" --arg status "$STATUS" --arg message "$MESSAGE" \
-      #       --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_REF_NAME" --arg sha "$GITHUB_SHA" \
-      #       --arg run_url "$RUN_URL" \
-      #       '{attachments: [{color: $color, title: ("Terraform Deployment: " + $status), text: $message, fields: [{title: "Repository", value: $repo, short: true}, {title: "Branch", value: $branch, short: true}, {title: "Commit", value: $sha, short: true}, {title: "Run URL", value: $run_url, short: false}]}]}')" \
-      #       $SLACK_WEBHOOK_URL
-
       - name: Notify Slack
         if: ${{ always() }}
         env:

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -264,11 +264,11 @@ jobs:
             fi
           fi
 
-      - name: Publish Terraform Plan
-        uses: actions/upload-artifact@v4
-        with:
-          name: tfplan
-          path: ${{ inputs.working_directory }}/tfplan
+      # - name: Publish Terraform Plan
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: tfplan
+      #     path: ${{ inputs.working_directory }}/tfplan
 
       - name: Create String Output
         id: tf-plan-string

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -114,6 +114,9 @@ on:
       SERVICE_ACCOUNT:
         required: false
         description: 'The service account to be used'
+      SLACK_WEBHOOK:
+        description: "Slack webhook URL"
+        required: true
 
 jobs:
   terraform-workflow:
@@ -296,4 +299,28 @@ jobs:
            cd ${{ inputs.working_directory }}
            terraform destroy -auto-approve
           fi
+
+      - name: Notify Slack
+        if: ${{ always() }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            STATUS="Success ✅"
+            COLOR="good"
+            MESSAGE="Terraform deployment completed successfully."
+          else
+            STATUS="Failed ❌"
+            COLOR="danger"
+            MESSAGE="Terraform deployment failed. Check logs for details."
+          fi
+
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg color "$COLOR" --arg status "$STATUS" --arg message "$MESSAGE" \
+            --arg repo "$GITHUB_REPOSITORY" --arg branch "$GITHUB_REF_NAME" --arg sha "$GITHUB_SHA" \
+            --arg run_url "$RUN_URL" \
+            '{attachments: [{color: $color, title: ("Terraform Deployment: " + $status), text: $message, fields: [{title: "Repository", value: $repo, short: true}, {title: "Branch", value: $branch, short: true}, {title: "Commit", value: $sha, short: true}, {title: "Run URL", value: $run_url, short: false}]}]}')" \
+            $SLACK_WEBHOOK_URL
 ...

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -70,6 +70,17 @@ on:
       AZURE_CREDENTIALS:
         required: false
         description: 'Azure Credentials to install Azure in github runner.'
+      AZURE_CLIENT_ID:
+        required: false
+        description: 'Client ID for service principal in Azure.'
+      AZURE_SUBSCRIPTION_ID:
+        required: false
+        description: 'Subscription ID in Azure.'
+      AZURE_TENANT_ID:
+        required: false
+      SUBSCRIPTION_ID:
+        required: false
+        description: 'Subscription ID of Azure.'
       AWS_ACCESS_KEY_ID:
         required: false
         description: 'AWS Access Key ID to install AWS CLI.'
@@ -165,8 +176,13 @@ jobs:
           actions_subcommand: 'fmt'
           path: ${{ inputs.working_directory }}
 
+
       - name: terraform init
         run: |
+           export ARM_CLIENT_ID="${{ secrets.CLIENT_ID }}"
+           export ARM_CLIENT_SECRET="${{ secrets.CLIENT_SECRET }}"
+           export ARM_TENANT_ID="${{ secrets.TENANT_ID }}"
+           export ARM_SUBSCRIPTION_ID="${{ secrets.SUBSCRIPTION_ID }}"
            cd ${{ inputs.working_directory }}
            terraform init
 
@@ -182,6 +198,10 @@ jobs:
         run: |
           export exitcode=0
           cd ${{ inputs.working_directory }}
+          export ARM_CLIENT_ID="${{ secrets.CLIENT_ID }}"
+          export ARM_CLIENT_SECRET="${{ secrets.CLIENT_SECRET }}"
+          export ARM_TENANT_ID="${{ secrets.TENANT_ID }}"
+          export ARM_SUBSCRIPTION_ID="${{ secrets.SUBSCRIPTION_ID }}"
           if [ "${{ inputs.destroy }}" = true ]; then
             if [ -n "${{ inputs.var_file }}" ]; then
               terraform plan -destroy -out tfplan --var-file=${{ inputs.var_file }}
@@ -230,6 +250,10 @@ jobs:
       - name: terraform apply
         if: ${{ inputs.destroy != true }}
         run: |
+          export ARM_CLIENT_ID="${{ secrets.CLIENT_ID }}"
+          export ARM_CLIENT_SECRET="${{ secrets.CLIENT_SECRET }}"
+          export ARM_TENANT_ID="${{ secrets.TENANT_ID }}"
+          export ARM_SUBSCRIPTION_ID="${{ secrets.SUBSCRIPTION_ID }}"        
           if [ -n "${{ inputs.var_file }}" ]; then
            cd ${{ inputs.working_directory }}
            terraform apply -var-file="${{ inputs.var_file }}" -auto-approve
@@ -260,6 +284,10 @@ jobs:
         if: ${{ inputs.destroy == true }}
         id: destroy
         run: |
+          export ARM_CLIENT_ID="${{ secrets.CLIENT_ID }}"
+          export ARM_CLIENT_SECRET="${{ secrets.CLIENT_SECRET }}"
+          export ARM_TENANT_ID="${{ secrets.TENANT_ID }}"
+          export ARM_SUBSCRIPTION_ID="${{ secrets.SUBSCRIPTION_ID }}"
           if [ -n "${{ inputs.var_file }}" ]; then
            cd ${{ inputs.working_directory }}
            terraform destroy -var-file="${{ inputs.var_file }}" -auto-approve

--- a/.github/workflows/terraform_workflow.yml
+++ b/.github/workflows/terraform_workflow.yml
@@ -260,10 +260,10 @@ jobs:
           export ARM_SUBSCRIPTION_ID="${{ secrets.AZURE_SUBSCRIPTION_ID }}"        
           if [ -n "${{ inputs.var_file }}" ]; then
            cd ${{ inputs.working_directory }}
-           terraform apply -var-file="${{ inputs.var_file }}" -auto-approve
+           terraform apply -var-file="${{ inputs.var_file }}" -auto-approve -parallelism=5
           else
            cd ${{ inputs.working_directory }}
-           terraform apply -auto-approve
+           terraform apply -auto-approve -parallelism=5
           fi
 
       - name: Find Errored Terraform State
@@ -294,10 +294,10 @@ jobs:
           export ARM_SUBSCRIPTION_ID="${{ secrets.AZURE_SUBSCRIPTION_ID }}"
           if [ -n "${{ inputs.var_file }}" ]; then
            cd ${{ inputs.working_directory }}
-           terraform destroy -var-file="${{ inputs.var_file }}" -auto-approve
+           terraform destroy -var-file="${{ inputs.var_file }}" -auto-approve -parallelism=5
           else
            cd ${{ inputs.working_directory }}
-           terraform destroy -auto-approve
+           terraform destroy -auto-approve -parallelism=5
           fi
 
       - name: Notify Slack


### PR DESCRIPTION
## what
* Updated the terraform_workflow to support azure cloud terraform deployment, Updated the tf apply, destroy steps for it
* Also added slack notification support for the workflow
* Added various parameters regarding the workflow run , including skipapproval
* Added parallelism flag for terraform apply and destroy for large deployment
## why
* Updated the workflow as , the workflow was not authorizing for azure using service principal
* There was no slack notification support earlier
* There were no required parameters for azure authentication
## references
* [Azure Provider: Authenticating using a Service Principal with a Client Secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret)