### PR TITLE
Feat: Stale PR shared workflow

### DIFF
--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -19,9 +19,6 @@ on:
         required: false
         type: number
         default: 10
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   stale:

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,0 +1,51 @@
+name: 'Stale Issues and PRs Cleaner'
+
+on:
+  workflow_call:
+    inputs:
+      days-before-issue-stale:
+        required: false
+        type: number
+        default: 30
+      days-before-pr-stale:
+        required: false
+        type: number
+        default: 30
+      days-before-issue-close:
+        required: false
+        type: number
+        default: 10
+      days-before-pr-close:
+        required: false
+        type: number
+        default: 10
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: ${{ inputs.days-before-issue-stale }}
+          days-before-pr-stale: ${{ inputs.days-before-pr-stale }}
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has been inactive for ${{ inputs.days-before-issue-stale }} days.  
+            Please remove the "stale" label or add a comment to keep it open. Otherwise, this issue will be closed in ${{ inputs.days-before-issue-close }} days.  
+          stale-pr-message: |
+            This PR has been automatically marked as stale because it has been inactive for ${{ inputs.days-before-pr-stale }} days.  
+            Please remove the "stale" label or add a comment to keep it open. Otherwise, this PR will be closed in ${{ inputs.days-before-pr-close }} days.  
+          exempt-issue-labels: bug,wip,on-hold,no-stale
+          exempt-pr-labels: bug,wip,on-hold,no-stale
+          exempt-all-milestones: true
+          days-before-issue-close: ${{ inputs.days-before-issue-close }}
+          days-before-pr-close: ${{ inputs.days-before-pr-close }}
+          delete-branch: true
+          close-issue-message: This issue was automatically closed because of stale in ${{ inputs.days-before-issue-close }} days
+          close-pr-message: This PR was automatically closed because of stale in ${{ inputs.days-before-pr-close }} days
+          remove-stale-when-updated: true

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,3 +1,4 @@
+---
 name: 'Stale Issues and PRs Cleaner'
 
 on:
@@ -32,17 +33,26 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           stale-issue-message: |
-            This issue has been automatically marked as stale because it has been inactive for ${{ inputs.days-before-issue-stale }} days.  
-            Please remove the "stale" label or add a comment to keep it open. Otherwise, this issue will be closed in ${{ inputs.days-before-issue-close }} days.  
+            This issue has been automatically marked as stale because it has been inactive
+            for ${{ inputs.days-before-issue-stale }} days. Please remove the "stale" label
+            or add a comment to keep it open. Otherwise, this issue will be closed in
+            ${{ inputs.days-before-issue-close }} days.
           stale-pr-message: |
-            This PR has been automatically marked as stale because it has been inactive for ${{ inputs.days-before-pr-stale }} days.  
-            Please remove the "stale" label or add a comment to keep it open. Otherwise, this PR will be closed in ${{ inputs.days-before-pr-close }} days.  
+            This PR has been automatically marked as stale because it has been inactive
+            for ${{ inputs.days-before-pr-stale }} days. Please remove the "stale" label
+            or add a comment to keep it open. Otherwise, this PR will be closed in
+            ${{ inputs.days-before-pr-close }} days.
           exempt-issue-labels: bug,wip,on-hold,no-stale
           exempt-pr-labels: bug,wip,on-hold,no-stale
           exempt-all-milestones: true
           days-before-issue-close: ${{ inputs.days-before-issue-close }}
           days-before-pr-close: ${{ inputs.days-before-pr-close }}
           delete-branch: true
-          close-issue-message: This issue was automatically closed because of stale in ${{ inputs.days-before-issue-close }} days
-          close-pr-message: This PR was automatically closed because of stale in ${{ inputs.days-before-pr-close }} days
+          close-issue-message: >
+            This issue was automatically closed because of stale in
+            ${{ inputs.days-before-issue-close }} days
+          close-pr-message: >
+            This PR was automatically closed because of stale in
+            ${{ inputs.days-before-pr-close }} days
           remove-stale-when-updated: true
+...

--- a/docs/stale-pr.md
+++ b/docs/stale-pr.md
@@ -1,0 +1,43 @@
+## [Stale Issues and PRs Workflow](https://github.com/clouddrove/github-shared-workflows/blob/master/.github/workflows/stale_pr.yml)
+
+This workflow automatically marks and closes stale issues and pull requests after periods of inactivity. `.github/workflows/stale_pr.yml`
+
+### Overview
+Automatically:
+- Marks issues as stale after 30 days of inactivity
+- Marks PRs as stale after 30 days of inactivity
+- Closes stale issues after 10 more days
+- Closes stale PRs after 10 more days
+- Deletes branches of closed PRs
+- Exempts items with specific labels or milestones
+
+### Features
+- Configurable time periods for staleness and closure
+- Customizable stale and close messages
+- Exclusion for items with specific labels (`bug`, `wip`, `on-hold`, `no-stale`)
+- Exclusion for all items with milestones
+- Automatic branch cleanup for closed PRs
+
+### Usage
+This workflow is designed to be called from other workflows using GitHub's `workflow_call` trigger.
+
+#### Example Implementation
+```yaml
+name: 'Mark or close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '0 0 * * 5'  # Runs every Friday midnight
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  stale-pr:
+    uses: clouddrove/github-shared-workflows/.github/workflows/stale_pr.yml@master
+    with:
+      days-before-issue-stale: 30  # Days until issue marked stale
+      days-before-pr-stale: 30     # Days until PR marked stale
+      days-before-issue-close: 10  # Days after stale until issue closed
+      days-before-pr-close: 10     # Days after stale until PR closed


### PR DESCRIPTION
## what
* Added a shared workflow for "Stale Issues and PRs Cleaner" to automatically mark inactive issues and PRs as stale, and close them after a defined period of inactivity.

## why
* To ensure better repository management by identifying and handling stale issues and PRs, reducing manual workload, and maintaining a clean and organized project.
* Addressing the issue -> https://github.com/clouddrove/Terraform-Azure-Modules/issues/6

