### PR TITLE
Feat: Addend pr-lock workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,9 +1,26 @@
+---
 name: 'Lock Threads'
 on:
   workflow_call:
+    inputs:
+      issue-inactive-days:
+        description: 'Number of days of inactivity before a closed issue is locked'
+        type: number
+        default: '30'
+      pr-inactive-days:
+        description: 'Number of days of inactivity before a closed pull request is locked'
+        type: number
+        default: '30'
+      discussion-inactive-days: 
+        description: 'Number of days of inactivity before a closed discussion is locked'
+        type: number
+        default: '30'
+
     secrets:
       github-token:
         required: true
+
+
 
 permissions:
   issues: write
@@ -20,8 +37,13 @@ jobs:
           issue-comment: >
             I'm going to lock this issue because it has been closed for *30 days* ⏳. This helps our maintainers find and focus on the active issues.
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          issue-inactive-days: '30'
+          issue-inactive-days: ${{ inputs.issue-inactive-days }}
           pr-comment: >
             I'm going to lock this pull request because it has been closed for *30 days* ⏳. This helps our maintainers find and focus on the active issues.
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          pr-inactive-days: '30'
+          pr-inactive-days: ${{ inputs.pr-inactive-days }}
+          discussion-comment: >
+            I'm going to lock this pull request because it has been closed for *30 days* ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          discussion-inactive-days: ${{ inputs.discussion-inactive-days }}
+...

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -33,15 +33,15 @@ jobs:
         with:
           github-token: ${{ secrets.github-token }}
           issue-comment: >
-            I'm going to lock this issue because it has been closed for *30 days* ⏳. This helps our maintainers find and focus on the active issues.
+            I'm going to lock this issue because it has been closed for *${{ inputs.issue-inactive-days }} days* ⏳. This helps our maintainers find and focus on the active issues.
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
           issue-inactive-days: ${{ inputs.issue-inactive-days }}
           pr-comment: >
-            I'm going to lock this pull request because it has been closed for *30 days* ⏳. This helps our maintainers find and focus on the active issues.
+            I'm going to lock this pull request because it has been closed for *${{ inputs.pr-inactive-days }} days* ⏳. This helps our maintainers find and focus on the active issues.
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
           pr-inactive-days: ${{ inputs.pr-inactive-days }}
           discussion-comment: >
-            I'm going to lock this pull request because it has been closed for *30 days* ⏳. This helps our maintainers find and focus on the active issues.
+            I'm going to lock this pull request because it has been closed for *${{ inputs.discussion-inactive-days }} days* ⏳. This helps our maintainers find and focus on the active issues.
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
           discussion-inactive-days: ${{ inputs.discussion-inactive-days }}
 ...

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,27 @@
+name: 'Lock Threads'
+on:
+  workflow_call:
+    secrets:
+      github-token:
+        required: true
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lock issues
+        uses: dessant/lock-threads@v5
+        with:
+          github-token: ${{ secrets.github-token }}
+          issue-comment: >
+            I'm going to lock this issue because it has been closed for *30 days* ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          issue-inactive-days: '30'
+          pr-comment: >
+            I'm going to lock this pull request because it has been closed for *30 days* ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          pr-inactive-days: '30'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -11,7 +11,7 @@ on:
         description: 'Number of days of inactivity before a closed pull request is locked'
         type: number
         default: '30'
-      discussion-inactive-days: 
+      discussion-inactive-days:
         description: 'Number of days of inactivity before a closed discussion is locked'
         type: number
         default: '30'
@@ -19,8 +19,6 @@ on:
     secrets:
       github-token:
         required: true
-
-
 
 permissions:
   issues: write

--- a/docs/lock.md
+++ b/docs/lock.md
@@ -1,0 +1,55 @@
+**---**
+**## [Lock Threads Workflow](https://github.com/dessant/lock-threads)**
+This GitHub Action automatically locks closed issues, pull requests, and discussions after a period of inactivity.
+
+<img width="800" src="https://raw.githubusercontent.com/dessant/lock-threads/main/assets/screenshot.png">
+
+**### Overview**
+Automatically locks:
+- Closed issues after defined period of inactivity (default 365 days)
+- Closed pull requests after defined period of inactivity (default 365 days)
+- Closed discussions after defined period of inactivity (default 365 days)
+- Supports comprehensive filtering options for which items to lock
+
+**### Features**
+- Filtering by creation and closure dates
+- Label-based inclusion and exclusion rules
+- Ability to add/remove labels before locking
+- Custom comment posting before locking
+- Configurable lock reasons
+- Process only specific item types (issues, PRs, discussions)
+- Detailed output logging of locked items
+- Uses GitHub's updated search qualifier to determine inactivity
+
+**### Usage**
+This workflow can run on a schedule or be manually triggered with workflow_dispatch.
+
+**#### Example Implementation**
+```yaml
+name: 'Lock Threads'
+permissions:
+    issues: write
+    pull-requests: write
+    
+on:
+  schedule:
+    - cron: '50 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  lock:
+    uses: clouddrove-sandbox/terraform-shared-workflows/.github/workflows/lock-thread.yml@master
+    secrets:
+      github-token: ${{ secrets.REPO_TOKEN }}
+```
+
+**#### Optional Configuration**
+```yaml
+with:
+  issue-inactive-days: '30'  # Days before locking inactive issues
+  pr-inactive-days: '30'     # Days before locking inactive PRs  
+  include-any-issue-labels: 'outdated, resolved'  # Only lock issues with these labels
+  exclude-any-pr-labels: 'wip'  # Don't lock PRs with these labels
+  issue-comment: 'This issue has been locked due to inactivity'  # Comment before locking
+  process-only: 'issues, prs'  # Only process specific item types
+```


### PR DESCRIPTION
**What**
* Added new Lock Threads workflow to automate:
   * *Auto-locking of closed issues after inactivity
   * Auto-locking of closed PRs after inactivity
   * Auto-locking of closed discussions after inactivity
* Included a `README` documenting:
   * Workflow features
   * Usage instructions
   * Configuration options

**Why**
* **Repository Maintenance**: Automatically manages closed threads to reduce clutter
* **Automation**: Eliminates manual monitoring and locking of inactive threads
* **Customization**: Offers extensive filtering options for targeted locking
* **Documentation**: Comprehensive examples for implementation in any repo
* **Resource Management**: Helps prevent reopening of resolved or outdated issues