### PR TITLE
feat: Updated Tag Release Workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB }}
           tag: ${{ steps.calc_version.outputs.new_version }}
-          includeInvalidCommits: true
+          includeInvalidCommits: false
           writeToFile: true
           changelogFilePath: CHANGELOG.md
           includeRefIssues: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,8 +9,9 @@ on:
         type: string
         default: master
     secrets:
-      GH_TOKEN:
+      GITHUB:
         required: true
+        description: 'PAT of the user to run the jobs.'
 
 jobs:
   release:
@@ -21,6 +22,7 @@ jobs:
       - name: 📦 Checkout the repository
         uses: actions/checkout@v5
         with:
+          token: ${{ secrets.GITHUB }}
           fetch-depth: 0
 
       - name: ⚙️ Set up Git
@@ -48,13 +50,13 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: 🔖 Get latest tag (or v0.0.0 if none)
+      - name: 🔖 Get latest tag (or 1.0.0 if none)
         id: get_latest_tag
         run: |
           git fetch --tags
-          LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
+          LATEST_TAG=$(git tag --list --sort=-v:refname | head -n 1)
           if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="v0.0.0"
+            LATEST_TAG="1.0.0"
           fi
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 
@@ -63,7 +65,6 @@ jobs:
         if: steps.skip_tag.outputs.skip == 'false'
         run: |
           BASE_VERSION="${{ steps.get_latest_tag.outputs.latest_tag }}"
-          BASE_VERSION="${BASE_VERSION#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
           LABELS="${{ steps.pr_labels.outputs.labels }}"
           if [[ "$LABELS" == *"major"* ]]; then
@@ -75,21 +76,21 @@ jobs:
           else
             PATCH=$((PATCH+1))
           fi
-          NEW_VERSION="v$MAJOR.$MINOR.$PATCH"
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: 🏷️ Create GitHub tag for the new version
         if: steps.skip_tag.outputs.skip == 'false'
         run: |
           git tag ${{ steps.calc_version.outputs.new_version }}
-          git push https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }} ${{ steps.calc_version.outputs.new_version }}
+          git push https://x-access-token:${{ secrets.GITHUB }}@github.com/${{ github.repository }} ${{ steps.calc_version.outputs.new_version }}
 
       - name: 📝 Generate Changelog
         if: steps.skip_tag.outputs.skip == 'false'
         id: changelog
         uses: requarks/changelog-action@v1
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB }}
           tag: ${{ steps.calc_version.outputs.new_version }}
           includeInvalidCommits: true
           writeToFile: true
@@ -102,7 +103,7 @@ jobs:
         if: steps.skip_tag.outputs.skip == 'false'
         uses: ncipollo/release-action@v1
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB }}
           tag: ${{ steps.calc_version.outputs.new_version }}
           name: ${{ steps.calc_version.outputs.new_version }}
           allowUpdates: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -22,13 +22,7 @@ jobs:
       - name: 📦 Checkout the repository
         uses: actions/checkout@v5
         with:
-          token: ${{ secrets.GITHUB }}
           fetch-depth: 0
-
-      - name: ⚙️ Set up Git
-        run: |
-          git config --global user.email "84795582+clouddrove-ci@users.noreply.github.com"
-          git config --global user.name "clouddrove-ci"
 
       - name: 🧩 Install jq
         run: |

--- a/docs/24.tag-release.md
+++ b/docs/24.tag-release.md
@@ -1,26 +1,27 @@
 ## [Tag Release](https://github.com/clouddrove/github-shared-workflows/blob/master/.github/workflows/tag-release.yml)
-This reusable workflow automatically bumps semantic version tags (vX.Y.Z) and generates a categorized changelog on every PR merge, based on PR labels.
+This reusable workflow automatically bumps semantic version tags (X.Y.Z) and generates a categorized changelog on every PR merge, based on PR labels.
 Release notes include a compare link.
-It utilizes the workflows defined in `.github/workflows/tag-release.yaml`
+It utilizes the workflows defined in `.github/workflows/tag-release.yml`
 
 ### Features
 
-- Label-driven versioning based on semantic versioning
-- Automatic changelog generation
-- Auto-tagging with vX.Y.Z format
-- Skips tagging when needed via label
+- Label-driven versioning based on semantic versioning  
+- Automatic changelog generation  
+- Auto-tagging with `x.y.z` format  
+- Skips tagging when needed via label  
+
+By default, the first release starts at **`1.0.0`**. After that, all new releases are created based on the label applied to the PR.  
 
 ### Label Behavior
 
 Before merging a PR, apply one of the following labels to control the version bump:
 
-| Label   | Effect on Version        | Example Change       |
-|---------|--------------------------|-----------------------|
-| major   | Increases major version  | v1.2.3 → v2.0.0       |
-| minor   | Increases minor version  | v1.2.3 → v1.3.0       |
-| patch   | Increases patch version  | v1.2.3 → v1.2.4       |
-| no-tag  | No new tag or release    | (skips tagging)       |
-
+| Label   | Effect on Version        | Example Change |
+|---------|--------------------------|----------------|
+| major   | Increases major version  | 1.2.3 → 2.0.0  |
+| minor   | Increases minor version  | 1.2.3 → 1.3.0  |
+| patch   | Increases patch version  | 1.2.3 → 1.2.4  |
+| no-tag  | No new tag or release    | (skips tagging) |
 
 
 ### Usage

--- a/docs/24.tag-release.md
+++ b/docs/24.tag-release.md
@@ -1,4 +1,4 @@
-## [Tag Release](https://github.com/clouddrove/github-shared-workflows/blob/master/.github/workflows/tag-release.yaml)
+## [Tag Release](https://github.com/clouddrove/github-shared-workflows/blob/master/.github/workflows/tag-release.yml)
 This reusable workflow automatically bumps semantic version tags (vX.Y.Z) and generates a categorized changelog on every PR merge, based on PR labels.
 Release notes include a compare link.
 It utilizes the workflows defined in `.github/workflows/tag-release.yaml`
@@ -34,9 +34,9 @@ on:
 
 jobs:
   release:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tag-release.yaml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tag-release.yml@master
     with:
       target_branch: master
     secrets:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB: ${{ secrets.GITHUB }}
 ```


### PR DESCRIPTION
## What
- Updated Tag Release Workflow 
- Added Support for GitHub Token 
- Minimum Version Starts from 1.0.0
- Removed v Prefix Before the Release Version

## Why
- The Earlier Base Release Started from 0.0.0
- Fixed Changelog Error Due to Branching Protection Rule
