### PR TITLE
ci: updated syntax for workflow (terraform-difference)

### DIFF
--- a/.github/workflows/tf-pr-checks.yaml
+++ b/.github/workflows/tf-pr-checks.yaml
@@ -138,7 +138,7 @@ jobs:
 
       - name: 🚀 Terraform Init (target branch)
         working-directory: ${{ inputs.terraform_directory }}
-        run: terraform init
+        run: terraform init -upgrade
 
       - name: 📐 Terraform Plan (target branch)
         working-directory: ${{ inputs.terraform_directory }}


### PR DESCRIPTION
## what
* updated the terraform difference workflows to allow terraform init -upgrade

## why
* When PR merge to Master, this change allow terraform init in the master when version is difference between PR and Master branch


