### PR TITLE
fix: Updated Release Condition Logic

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -40,7 +40,7 @@ jobs:
         id: skip_tag
         run: |
           LABELS="${{ steps.pr_labels.outputs.labels }}"
-          
+
           # Check if any version label exists (major/minor/patch)
           if [[ "$LABELS" == *"major"* || "$LABELS" == *"minor"* || "$LABELS" == *"patch"* ]]; then
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -68,7 +68,7 @@ jobs:
           BASE_VERSION="${{ steps.get_latest_tag.outputs.latest_tag }}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
           LABELS="${{ steps.pr_labels.outputs.labels }}"
-          
+
           if [[ "$LABELS" == *"major"* ]]; then
             MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0
             echo "version_type=major" >> $GITHUB_OUTPUT
@@ -79,7 +79,7 @@ jobs:
             PATCH=$((PATCH+1))
             echo "version_type=patch" >> $GITHUB_OUTPUT
           fi
-          
+
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
@@ -117,9 +117,9 @@ jobs:
           makeLatest: true
           body: |
             ${{ steps.changelog.outputs.changes }}
-            
+
             **Release Type:** ${{ steps.calc_version.outputs.version_type }}
-            
+
             [Compare changes](https://github.com/${{ github.repository }}/compare/${{ steps.get_latest_tag.outputs.latest_tag }}...${{ steps.calc_version.outputs.new_version }})
 
       - name: 💾 Commit CHANGELOG.md

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB }}
 
       - name: 🧩 Install jq
         run: |
@@ -35,17 +36,23 @@ jobs:
           LABELS=$(jq -r '.pull_request.labels | map(.name) | join(",")' "$GITHUB_EVENT_PATH")
           echo "labels=$LABELS" >> $GITHUB_OUTPUT
 
-      - name: 🚫 Check for no-tag label
+      - name: 🚫 Check for release conditions
         id: skip_tag
         run: |
-          if [[ "${{ steps.pr_labels.outputs.labels }}" == *"no-tag"* ]]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
+          LABELS="${{ steps.pr_labels.outputs.labels }}"
+          
+          # Check if any version label exists (major/minor/patch)
+          if [[ "$LABELS" == *"major"* || "$LABELS" == *"minor"* || "$LABELS" == *"patch"* ]]; then
             echo "skip=false" >> $GITHUB_OUTPUT
+            echo "reason=version label found" >> $GITHUB_OUTPUT
+          else
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=no valid label found, skipping" >> $GITHUB_OUTPUT
           fi
 
       - name: 🔖 Get latest tag (or 1.0.0 if none)
         id: get_latest_tag
+        if: steps.skip_tag.outputs.skip == 'false'
         run: |
           git fetch --tags
           LATEST_TAG=$(git tag --list --sort=-v:refname | head -n 1)
@@ -61,23 +68,28 @@ jobs:
           BASE_VERSION="${{ steps.get_latest_tag.outputs.latest_tag }}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
           LABELS="${{ steps.pr_labels.outputs.labels }}"
+          
           if [[ "$LABELS" == *"major"* ]]; then
             MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0
+            echo "version_type=major" >> $GITHUB_OUTPUT
           elif [[ "$LABELS" == *"minor"* ]]; then
             MINOR=$((MINOR+1)); PATCH=0
+            echo "version_type=minor" >> $GITHUB_OUTPUT
           elif [[ "$LABELS" == *"patch"* ]]; then
             PATCH=$((PATCH+1))
-          else
-            PATCH=$((PATCH+1))
+            echo "version_type=patch" >> $GITHUB_OUTPUT
           fi
+          
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: 🏷️ Create GitHub tag for the new version
         if: steps.skip_tag.outputs.skip == 'false'
         run: |
+          git config user.name "clouddrove-ci"
+          git config user.email "84795582+clouddrove-ci@users.noreply.github.com"
           git tag ${{ steps.calc_version.outputs.new_version }}
-          git push https://x-access-token:${{ secrets.GITHUB }}@github.com/${{ github.repository }} ${{ steps.calc_version.outputs.new_version }}
+          git push origin ${{ steps.calc_version.outputs.new_version }}
 
       - name: 📝 Generate Changelog
         if: steps.skip_tag.outputs.skip == 'false'
@@ -105,6 +117,9 @@ jobs:
           makeLatest: true
           body: |
             ${{ steps.changelog.outputs.changes }}
+            
+            **Release Type:** ${{ steps.calc_version.outputs.version_type }}
+            
             [Compare changes](https://github.com/${{ github.repository }}/compare/${{ steps.get_latest_tag.outputs.latest_tag }}...${{ steps.calc_version.outputs.new_version }})
 
       - name: 💾 Commit CHANGELOG.md
@@ -121,8 +136,9 @@ jobs:
       - name: 📋 Action Summary
         run: |
           if [[ "${{ steps.skip_tag.outputs.skip }}" == "true" ]]; then
-            echo "🚫 Release skipped due to 'no-tag' label."
+            echo "🚫 Release skipped: ${{ steps.skip_tag.outputs.reason }}"
           else
             echo "✅ Released ${{ steps.calc_version.outputs.new_version }} successfully."
+            echo "🏷️ Version type: ${{ steps.calc_version.outputs.version_type }}"
           fi
 ...


### PR DESCRIPTION
## what
* Fixed tag-release workflow to prevent accidental releases when no version labels are present on PRs
* Enhanced authentication mechanism for proper tag creation and GitHub release publishing
* Improved conditional step execution to skip unnecessary workflow steps when releases are not triggered

## why
* Original workflow was automatically creating patch releases even without explicit version labels, causing unintended version bumps
* Need explicit developer control over releases - only trigger when `major`, `minor`, or `patch` labels are present on merged PRs
* GitHub token authentication issues were preventing successful tag pushing and release creation
