### PR TITLE
fix: pass default subjectPattern in compat alias to prevent empty override

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -23,10 +23,10 @@ jobs:
   delegate:
     uses: ./.github/workflows/pr-checks.yml
     with:
-      types: ${{ inputs.types }}
-      requireScope: ${{ inputs.requireScope }}
-      subjectPattern: ${{ inputs.subjectPattern }}
-      validateSingleCommit: ${{ inputs.validateSingleCommit }}
-      checkLabels: ${{ inputs.checkLabels }}
+      types: ${{ inputs.types || '' }}
+      requireScope: ${{ inputs.requireScope || false }}
+      subjectPattern: ${{ inputs.subjectPattern || '[A-Za-z].+' }}
+      validateSingleCommit: ${{ inputs.validateSingleCommit || false }}
+      checkLabels: ${{ inputs.checkLabels || false }}
     secrets: inherit
 ...


### PR DESCRIPTION
## Summary
- The `pr_checks.yml` compat alias forwards `subjectPattern` to `pr-checks.yml`
- When callers don't pass `subjectPattern`, it sends empty string instead of letting the default `[A-Za-z].+` kick in
- This causes the PR title regex to be `^(type)(\(scope\))?\s+$` which matches nothing
- Fix: use `${{ inputs.subjectPattern || '[A-Za-z].+' }}` to preserve the default

## Test plan
- [ ] Verify PRs using `pr_checks.yml` (underscore) now pass title validation
- [ ] Verify PRs using `pr-checks.yml` (hyphen) are unaffected