### PR TITLE
ci(release-changelog): set tag_format default to vX.Y.Z

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -9,7 +9,8 @@ on:
         type: string
         description: "Branch to update CHANGELOG from"
       tag_format:
-        required: true
+        required: false
+        default: 'vX.Y.Z'
         type: string
         description: "Repository tag format (e.g., vX.Y.Z or X.Y.Z)"
       release_tag:

--- a/docs/release-changelog.md
+++ b/docs/release-changelog.md
@@ -22,7 +22,7 @@ clouddrove/github-shared-workflows/.github/workflows/release-changelog.yml@v2
 | Name         | Required | Type   | Description |
 |--------------|----------|--------|-------------|
 | `branch`     | ✅ Yes   | string | Target branch where CHANGELOG.md will be committed |
-| `tag_format` | ✅ Yes   | string | Repository tag format (`vX.Y.Z` or `X.Y.Z`) |
+| `tag_format` | ❌ No    | string | Repository tag format (`vX.Y.Z` or `X.Y.Z`)  default : vX.Y.Z |
 | `release_tag`| ✅ Yes   | string | Actual release tag to validate |
 
 ---
@@ -97,7 +97,7 @@ jobs:
     uses: clouddrove/github-shared-workflows/.github/workflows/release-changelog.yml@v2
     with:
       branch: master
-      tag_format: vX.Y.Z
+      tag_format: vX.Y.Z //Repository tag format (`vX.Y.Z` or `X.Y.Z`)  default : vX.Y.Z
       release_tag: ${{ github.ref_name }}
     secrets:
       GITHUB: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
  - Set the default tag format to vX.Y.Z in CI workflows.

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix
- [ ] ✨ New workflow
- [X] 📝 Documentation update
- [X] 🔧 Workflow enhancement
- [X] 🎨 Code style/formatting
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security improvement

## Workflow Category
<!-- If adding/modifying a workflow, select the category -->

- [ ] Terraform (`tf-*`)
- [ ] CloudFormation (`cf-*`)
- [ ] Docker (`docker-*`)
- [ ] Helm (`helm-*`)
- [ ] PR Automation (`pr-*`)
- [ ] Security (`security-*`)
- [X] Release (`release-*`)
- [ ] Notification (`notify-*`)
- [ ] AWS-specific (`aws-*`)
- [ ] GCP-specific (`gcp-*`)
- [ ] YAML Lint (`yl-*`)
- [ ] Other

## Checklist
<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

