### PR TITLE
fix(readme): update checkout version in readme.yml shared workflow

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
 
       - name: 📦 Checkout Repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: master

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -16,6 +16,6 @@ jobs:
   assignee:
     uses: clouddrove/github-shared-workflows/.github/workflows/readme.yml@v2
     secrets:
-      TOKEN :                  # Provide GitHub token 
-      SLACK_WEBHOOK_TERRAFORM: # Provide slack-webhook url
+      TOKEN : ${{ secrets.GITHUB }}        # Provide GitHub token 
+      SLACK_WEBHOOK_TERRAFORM:             # Provide slack-webhook url
 ```


### PR DESCRIPTION
## Changes

* Switched checkout to actions/checkout@v4 for compatibility with clouddrove/github-actions@9.0.3, which copies the repo into new-workflow/ before running its push command.