### PR TITLE
fix(release-changelog): update tag format in release changelog internal workflows

### DIFF
--- a/.github/workflows/release-changelog-internal.yml
+++ b/.github/workflows/release-changelog-internal.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/release-changelog.yml
     with:
       branch: 'master'
-      tag_format: X.Y.Z
+      tag_format: vX.Y.Z
       release_tag: ${{ github.ref_name }}
     secrets:
       GITHUB: ${{ secrets.GITHUB }}

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -17,14 +17,6 @@ on:
         required: true
         type: string
         description: "Actual release tag to validate and use"
-      version_type:
-        required: true
-        type: string
-        description: "Type of release (major/minor/patch)"
-      latest_tag:
-        required: true
-        type: string
-        description: "Previous tag for comparison"
 
     secrets:
       GITHUB:
@@ -108,14 +100,7 @@ jobs:
           allowUpdates: true
           draft: false
           makeLatest: true
-          body: |
-            ${{ steps.changelog.outputs.changes }}
-
-            **Release Type:** ${{ inputs.version_type }}
-
-            ${{ inputs.version_type == 'major' && '⚠️ **BREAKING CHANGES:** This is a major release with breaking changes. Please review the breaking changes section in [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ inputs.release_tag }}/CHANGELOG.md) before upgrading.' || '' }}
-
-            [Compare changes](https://github.com/${{ github.repository }}/compare/${{ inputs.latest_tag }}...${{ inputs.release_tag }})
+          body: ${{ steps.changelog.outputs.changes }}
 
       - name: 💾 Commit CHANGELOG.md
         uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -152,7 +152,5 @@ jobs:
       branch: ${{ inputs.target_branch }}
       tag_format: ${{ inputs.tag_format }}
       release_tag: ${{ needs.create-tag.outputs.final_tag }}
-      version_type: ${{ needs.create-tag.outputs.version_type }}
-      latest_tag: ${{ needs.create-tag.outputs.latest_tag }}
     secrets:
       GITHUB: ${{ secrets.GITHUB }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -18,10 +18,6 @@ on:
         type: boolean
         default: true
         description: "Whether to create changelog and release (default: true)"
-      version_type:
-        required: true
-        type: string
-        description: "Type of release (major/minor/patch)"
       latest_tag:
         required: false
         type: string

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -23,9 +23,9 @@ on:
         type: string
         description: "Type of release (major/minor/patch)"
       latest_tag:
-        required: true
+        required: false
         type: string
-        description: "Previous tag for comparison"
+        description: "Previous tag for comparison (optional - will be auto-detected if not provided)"
 
     secrets:
       GITHUB:
@@ -76,14 +76,24 @@ jobs:
             echo "reason=no valid label found, skipping" >> $GITHUB_OUTPUT
           fi
 
-      - name: 🔖 Get latest tag (or 1.0.0 if none)
+      - name: 🔖 Get latest tag (or use provided latest_tag or default to 1.0.0)
         id: get_latest_tag
         if: steps.skip_tag.outputs.skip == 'false'
         run: |
-          git fetch --tags
-          LATEST_TAG=$(git tag --list --sort=-v:refname | head -n 1)
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="1.0.0"
+          # First, check if latest_tag was provided as input
+          if [ -n "${{ inputs.latest_tag }}" ]; then
+            LATEST_TAG="${{ inputs.latest_tag }}"
+            echo "Using provided latest_tag: $LATEST_TAG"
+          else
+            # Otherwise, fetch from git tags
+            git fetch --tags
+            LATEST_TAG=$(git tag --list --sort=-v:refname | head -n 1)
+            if [ -z "$LATEST_TAG" ]; then
+              LATEST_TAG="1.0.0"
+              echo "No existing tags found, defaulting to: $LATEST_TAG"
+            else
+              echo "Found latest tag from git: $LATEST_TAG"
+            fi
           fi
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -18,6 +18,15 @@ on:
         type: boolean
         default: true
         description: "Whether to create changelog and release (default: true)"
+      version_type:
+        required: true
+        type: string
+        description: "Type of release (major/minor/patch)"
+      latest_tag:
+        required: true
+        type: string
+        description: "Previous tag for comparison"
+
     secrets:
       GITHUB:
         required: true

--- a/docs/release-tag.md
+++ b/docs/release-tag.md
@@ -42,6 +42,7 @@ jobs:
       target_branch: ${{ github.event.pull_request.base.ref }}
       tag_format: "vX.Y.Z"  # or "X.Y.Z" depending on your preference
       # create_changelog: false  # 👈 Disable changelog generation
+      # latest_tag: ${{ github.event.inputs.base_tag }} # "" # 👈 latest_tag is optional - will be auto-detected
     secrets:
       GITHUB: ${{ secrets.TOKEN_GITHUB }}
 ```


### PR DESCRIPTION
## Description
Update tag naming convention in release workflows to use the tag format **vX.Y.Z** instead of **X.Y.Z**.

## Type of Change
 Tag format - **vX.Y.Z** -> **X.Y.Z**.

- [ ] 🐛 Bug fix
- [ ] ✨ New workflow
- [ ] 📝 Documentation update
- [ ] 🔧 Workflow enhancement
- [ ] 🎨 Code style/formatting
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security improvement

## Workflow Category
<!-- If adding/modifying a workflow, select the category -->

- [ ] Terraform (`tf-*`)
- [ ] CloudFormation (`cf-*`)
- [ ] Docker (`docker-*`)
- [ ] Helm (`helm-*`)
- [ ] PR Automation (`pr-*`)
- [ ] Security (`security-*`)
- [X] Release (`release-*`)
- [ ] Notification (`notify-*`)
- [ ] AWS-specific (`aws-*`)
- [ ] GCP-specific (`gcp-*`)
- [ ] YAML Lint (`yl-*`)
- [ ] Other

## Checklist
<!-- Mark completed items with an 'x' -->

- [X] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

