### PR TITLE
fix(release-maintain-major-tag): update release-maintain-major-tag from X.Y.Z to vX.Y.Z format

### DIFF
--- a/.github/workflows/release-maintain-major-tag.yml
+++ b/.github/workflows/release-maintain-major-tag.yml
@@ -22,12 +22,12 @@ jobs:
 
           echo "Release tag: $TAG"
 
-          if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "valid=true" >> $GITHUB_OUTPUT
             echo "Tag format valid"
           else
             echo "valid=false" >> $GITHUB_OUTPUT
-            echo "Tag format invalid"
+            echo "Tag format invalid. Expected format: vX.Y.Z"
           fi
 
   update-major-tag:
@@ -54,7 +54,7 @@ jobs:
         run: |
           TAG=${{ github.event.release.tag_name }}
           MAJOR=$(echo "$TAG" | cut -d. -f1)
-          MAJOR_TAG="v$MAJOR"
+          MAJOR_TAG="$MAJOR"
 
           echo "Major tag: $MAJOR_TAG"
           echo "major_tag=$MAJOR_TAG" >> $GITHUB_OUTPUT

--- a/docs/release-maintain-major-tag.md
+++ b/docs/release-maintain-major-tag.md
@@ -1,6 +1,6 @@
 # Release - Maintain Major Tag
 
-Automatically maintains a **major version tag (`vX`)** when a new semantic version release (`X.Y.Z`) is published.
+Automatically maintains a **major version tag (`vX`)** when a new semantic version release (`vX.Y.Z`) is published.
 
 This workflow ensures that the major version tag always points to the **latest release of that major version**, making it easier for consumers to reference stable major versions.
 
@@ -11,8 +11,8 @@ This workflow ensures that the major version tag always points to the **latest r
 When a new release is published:
 
 1. The workflow validates the release tag format.
-2. Only **semantic version tags (`X.Y.Z`)** are processed.
-3. The workflow extracts the **major version (`X`)**.
+2. Only **semantic version tags (`vX.Y.Z`)** are processed.
+3. The workflow extracts the **major version (`vX`)**.
 4. It updates or creates the corresponding **major tag (`vX`)**.
 5. The major tag is force-pushed to point to the latest release.
 
@@ -20,9 +20,9 @@ Example:
 
 | Release Tag | Updated Major Tag |
 |-------------|------------------|
-| `1.0.0` | `v1` → `1.0.0` |
-| `1.2.3` | `v1` → `1.2.3` |
-| `2.0.0` | `v2` → `2.0.0` |
+| `v1.0.0` | `v1` → `v1.0.0` |
+| `v1.2.3` | `v1` → `v1.2.3` |
+| `v2.0.0` | `v2` → `v2.0.0` |
 
 ---
 


### PR DESCRIPTION
## Description
This change updates the version tagging format used in release-maintain-major-tag from `X.Y.Z` to `vX.Y.Z` to align with standard semantic versioning conventions.

- Updated version tag format to include v prefix (e.g., 1.2.3 → v1.2.3)
- Ensures consistency across release workflows and tooling
- Improves compatibility with Git tagging standards
- update docs

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [X] 🐛 Bug fix
- [ ] ✨ New workflow
- [X] 📝 Documentation update
- [ ] 🔧 Workflow enhancement
- [ ] 🎨 Code style/formatting
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security improvement

## Workflow Category
<!-- If adding/modifying a workflow, select the category -->

- [ ] Terraform (`tf-*`)
- [ ] CloudFormation (`cf-*`)
- [ ] Docker (`docker-*`)
- [ ] Helm (`helm-*`)
- [ ] PR Automation (`pr-*`)
- [ ] Security (`security-*`)
- [X] Release (`release-*`)
- [ ] Notification (`notify-*`)
- [ ] AWS-specific (`aws-*`)
- [ ] GCP-specific (`gcp-*`)
- [ ] YAML Lint (`yl-*`)
- [ ] Other

## Checklist

- [X] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
