### PR TITLE
fix: Run major tag workflow after changelog without duplicates

### DIFF
--- a/.github/workflows/release-changelog-internal.yml
+++ b/.github/workflows/release-changelog-internal.yml
@@ -15,4 +15,13 @@ jobs:
       release_tag: ${{ github.ref_name }}
     secrets:
       GITHUB: ${{ secrets.GITHUB }}
+
+  release-major-tag:
+    needs: changelog
+    if: always()
+    uses: ./.github/workflows/release-maintain-major-tag.yml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      GITHUB: ${{ secrets.GITHUB }}
 ...

--- a/.github/workflows/release-maintain-major-tag.yml
+++ b/.github/workflows/release-maintain-major-tag.yml
@@ -2,8 +2,15 @@
 name: Release - Maintain Major Tag
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'Tag name to update major version for'
+        required: true
+        type: string
+    secrets:
+      GITHUB:
+        required: true
 
 permissions:
   contents: write
@@ -18,7 +25,7 @@ jobs:
       - name: Check tag format
         id: check
         run: |
-          TAG=${{ github.event.release.tag_name }}
+          TAG="${{ inputs.tag_name }}"
 
           echo "Release tag: $TAG"
 
@@ -40,6 +47,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB }}
 
       - name: Fetch tags
         run: git fetch --tags
@@ -52,7 +60,7 @@ jobs:
       - name: Extract major version
         id: version
         run: |
-          TAG=${{ github.event.release.tag_name }}
+          TAG="${{ inputs.tag_name }}"
           MAJOR=$(echo "$TAG" | cut -d. -f1)
           MAJOR_TAG="$MAJOR"
 
@@ -61,7 +69,7 @@ jobs:
 
       - name: Update major tag
         run: |
-          git tag -f ${{ steps.version.outputs.major_tag }} ${{ github.event.release.tag_name }}
+          git tag -f ${{ steps.version.outputs.major_tag }} ${{ inputs.tag_name }}
 
       - name: Push major tag
         run: |

--- a/.github/workflows/tf-smurf.yml
+++ b/.github/workflows/tf-smurf.yml
@@ -3,7 +3,7 @@ name: 🦸‍♂️ Smurf Terraform workflow
 on:
   workflow_call:
     inputs:
-      working_directory:
+      terraform_directory:
         required: true
         type: string
         description: 'Root directory of the terraform where all resources exist.'

--- a/.github/workflows/tf-smurf.yml
+++ b/.github/workflows/tf-smurf.yml
@@ -35,8 +35,12 @@ on:
         description: 'Approvals list to approve apply or destroy'
       smurf_version:
         type: string
-        default: v0.0.9
+        default: latest
         description: 'Required Smurf version'
+      terraform_version:
+        type: string
+        default: 1.3.6
+        description: 'Required Terraform version'
       timeout:
         required: false
         type: number
@@ -177,6 +181,11 @@ jobs:
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
+      - name: 🛠️ Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+
       - name: ⚙️ Set up Smurf Terraform
         uses: clouddrove/smurf@v1.1.3
 
@@ -221,6 +230,11 @@ jobs:
     steps:
       - name: 📦 Checkout Repository
         uses: actions/checkout@v6
+
+      - name: 🛠️ Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
 
       - name: ⚙️ Set up Smurf Terraform
         uses: clouddrove/smurf@v1.1.3

--- a/docs/release-maintain-major-tag.md
+++ b/docs/release-maintain-major-tag.md
@@ -31,6 +31,11 @@ Example:
 The workflow runs when a **GitHub Release is published**.
 
 ```yaml
-on:
-  release:
-    types: [published]
+release-major-tag:
+  needs: changelog
+  if: always()
+  uses: clouddrove/github-shared-workflows/.github/workflows/release-maintain-major-tag.yml
+  with:
+    tag_name: ${{ github.ref_name }}
+  secrets:
+    GITHUB: ${{ secrets.GITHUB }}


### PR DESCRIPTION
## Description
Major tag workflow was running twice (once on release, once when called) and ordering wasn't guaranteed.

- Removed `release` trigger from major tag workflow
- Added `workflow_call` with `tag_name` input
- Updated caller workflow with `needs: changelog` and `if: always()`

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [X] 🐛 Bug fix
- [ ] ✨ New workflow
- [X] 📝 Documentation update
- [X] 🔧 Workflow enhancement
- [ ] 🎨 Code style/formatting
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security improvement

## Workflow Category
<!-- If adding/modifying a workflow, select the category -->

- [X] Terraform (`tf-*`)
- [ ] CloudFormation (`cf-*`)
- [ ] Docker (`docker-*`)
- [ ] Helm (`helm-*`)
- [ ] PR Automation (`pr-*`)
- [ ] Security (`security-*`)
- [X] Release (`release-*`)
- [ ] Notification (`notify-*`)
- [ ] AWS-specific (`aws-*`)
- [ ] GCP-specific (`gcp-*`)
- [ ] YAML Lint (`yl-*`)
- [ ] Other

## Checklist
<!-- Mark completed items with an 'x' -->

- [X] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published