### PR TITLE
fix(release-changelog-internal): remove duplicate tag validation and run workflows once during tag release

### DIFF
--- a/.github/workflows/release-changelog-internal.yml
+++ b/.github/workflows/release-changelog-internal.yml
@@ -4,7 +4,7 @@ permissions: write-all
 on:
   push: 
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 jobs:
   changelog:

--- a/.github/workflows/release-maintain-major-tag.yml
+++ b/.github/workflows/release-maintain-major-tag.yml
@@ -16,30 +16,7 @@ permissions:
   contents: write
 
 jobs:
-  check-tag:
-    runs-on: ubuntu-latest
-    outputs:
-      valid: ${{ steps.check.outputs.valid }}
-
-    steps:
-      - name: Check tag format
-        id: check
-        run: |
-          TAG="${{ inputs.tag_name }}"
-
-          echo "Release tag: $TAG"
-
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "valid=true" >> $GITHUB_OUTPUT
-            echo "Tag format valid"
-          else
-            echo "valid=false" >> $GITHUB_OUTPUT
-            echo "Tag format invalid. Expected format: vX.Y.Z"
-          fi
-
   update-major-tag:
-    needs: check-tag
-    if: needs.check-tag.outputs.valid == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/docs/release-maintain-major-tag.md
+++ b/docs/release-maintain-major-tag.md
@@ -10,11 +10,9 @@ This workflow ensures that the major version tag always points to the **latest r
 
 When a new release is published:
 
-1. The workflow validates the release tag format.
-2. Only **semantic version tags (`vX.Y.Z`)** are processed.
-3. The workflow extracts the **major version (`vX`)**.
-4. It updates or creates the corresponding **major tag (`vX`)**.
-5. The major tag is force-pushed to point to the latest release.
+1. The workflow extracts the **major version (`vX`)**.
+2. It updates or creates the corresponding **major tag (`vX`)**.
+3. The major tag is force-pushed to point to the latest release.
 
 Example:
 


### PR DESCRIPTION

## Description
This PR removes duplicate tag validation logic and ensures workflows are triggered only once during the tag release process.

## Changes
- Removed repeated tag validation checks
- Updated workflow execution logic for tag releases

## Impact
- Reduces unnecessary workflow executions
- Improves release process efficiency
- Avoids duplicate validations during tag creation

<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [X] 🐛 Bug fix
- [ ] ✨ New workflow
- [X] 📝 Documentation update
- [ ] 🔧 Workflow enhancement
- [ ] 🎨 Code style/formatting
- [X] ♻️ Refactoring
- [X] ⚡ Performance improvement
- [ ] 🔒 Security improvement

## Workflow Category
<!-- If adding/modifying a workflow, select the category -->

- [ ] Terraform (`tf-*`)
- [ ] CloudFormation (`cf-*`)
- [ ] Docker (`docker-*`)
- [ ] Helm (`helm-*`)
- [ ] PR Automation (`pr-*`)
- [ ] Security (`security-*`)
- [X] Release (`release-*`)
- [ ] Notification (`notify-*`)
- [ ] AWS-specific (`aws-*`)
- [ ] GCP-specific (`gcp-*`)
- [ ] YAML Lint (`yl-*`)
- [ ] Other

## Checklist
<!-- Mark completed items with an 'x' -->

- [X] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing
<!-- Describe the tests you ran -->

https://github.com/anket-cd/tes-repo/actions/runs/26285639006
