### PR TITLE
ci: add configurable runs-on input to smurf helm workflow

### DIFF
--- a/.github/workflows/smurf-helm-deploy.yml
+++ b/.github/workflows/smurf-helm-deploy.yml
@@ -20,6 +20,11 @@ on:
         type: string
         required: false
         default: v1.1.5
+      runs_on:
+        description: GitHub Actions runner to use
+        type: string
+        required: false
+        default: ubuntu-latest
 
       # ── AWS ──────────────────────────────────────────────────────────
       aws_region:
@@ -174,7 +179,7 @@ jobs:
   helm-lint:
     name: Helm Lint & Template
     if: ${{ inputs.helm_enable }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
     steps:
       - name: 📦 Checkout
         uses: actions/checkout@v7
@@ -202,7 +207,7 @@ jobs:
     name: Helm Deploy
     if: ${{ inputs.helm_enable }}
     needs: helm-lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.target_environment }}
     steps:
       - name: 📦 Checkout
@@ -308,7 +313,7 @@ jobs:
   helm-rollback:
     name: Helm Rollback
     if: ${{ inputs.helm_rollback_enable }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.target_environment }}
     steps:
       - name: 📦 Checkout


### PR DESCRIPTION
## Description

Added a configurable `runs-on` input to the Smurf Helm shared workflow. The runner can now be specified by the calling workflow, with `ubuntu-latest` used as the default when no runner is provided.

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New workflow
* [ ] 📝 Documentation update
* [x] 🔧 Workflow enhancement
* [ ] 🎨 Code style/formatting
* [ ] ♻️ Refactoring
* [ ] ⚡ Performance improvement
* [ ] 🔒 Security improvement

## Workflow Category

* [ ] Terraform (`tf-*`)
* [ ] CloudFormation (`cf-*`)
* [ ] Docker (`docker-*`)
* [x] Helm (`helm-*`)
* [ ] PR Automation (`pr-*`)
* [ ] Security (`security-*`)
* [ ] Release (`release-*`)
* [ ] Notification (`notify-*`)
* [ ] AWS-specific (`aws-*`)
* [ ] GCP-specific (`gcp-*`)
* [ ] YAML Lint (`yl-*`)
* [ ] Other

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have updated the documentation accordingly
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published

## Testing

* Verified the workflow YAML configuration.
* Verified that `runs-on` defaults to `ubuntu-latest`.
* Verified that the runner can be overridden through the `runs_on` workflow input.
* Verified the input is applied to the Helm lint, deploy, and rollback jobs.

## Screenshots/Documentation

No screenshots or documentation updates are required for this change.

## Related Issues

Closes #

## Additional Notes

The new `runs_on` input is optional and maintains backward compatibility. Existing callers that do not provide the input will continue to run on `ubuntu-latest`.
