### PR TITLE
feature(smurf-tf): allow callers to choose the runner

### DIFF
--- a/.github/workflows/smurf-tf-workflow.yml
+++ b/.github/workflows/smurf-tf-workflow.yml
@@ -60,6 +60,17 @@ on:
         default: 10
         description: Maximum timeout duration for the Terraform workflow execution.
 
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
+        description: >-
+          Runner label for both jobs. Defaults to the GitHub-hosted runner.
+          Set it to a self-hosted label when Terraform has to reach an endpoint
+          that is not on the public internet, such as a private EKS or AKS API
+          server: a GitHub-hosted runner has no route into the VPC, so those
+          plans fail on a connection timeout regardless of credentials.
+
       minimum-approvals:
         required: false
         type: string
@@ -157,7 +168,7 @@ jobs:
 
   terraform-plan:
     name: "⚙️ Terraform Init + Validate + Plan"
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.target_environment }}
 
     steps:
@@ -264,7 +275,7 @@ jobs:
     name: "${{ inputs.destroy && '🔥 Terraform Destroy' || '🚀 Terraform Apply' }}"
     needs: terraform-plan
     if: ${{ !inputs.plan_only }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     environment: ${{ inputs.target_environment }}
 
     steps:

--- a/.github/workflows/smurf-tf-workflow.yml
+++ b/.github/workflows/smurf-tf-workflow.yml
@@ -60,16 +60,20 @@ on:
         default: 10
         description: Maximum timeout duration for the Terraform workflow execution.
 
-      runner:
+      ## Named runs_on to match smurf-helm-deploy.yml, which already takes the
+      ## same input with the same default. One concept, one name.
+      runs_on:
         required: false
         type: string
         default: ubuntu-latest
         description: >-
-          Runner label for both jobs. Defaults to the GitHub-hosted runner.
-          Set it to a self-hosted label when Terraform has to reach an endpoint
-          that is not on the public internet, such as a private EKS or AKS API
-          server: a GitHub-hosted runner has no route into the VPC, so those
-          plans fail on a connection timeout regardless of credentials.
+          GitHub Actions runner to use, for both jobs. Defaults to the
+          GitHub-hosted runner. Set a self-hosted label when Terraform has to
+          reach an endpoint that is not on the public internet, such as a
+          private EKS or AKS API server: a GitHub-hosted runner has no route
+          into the VPC, so those plans fail on a connection timeout regardless
+          of credentials. A self-hosted runner must provide Docker, which the
+          approval gate's container action requires.
 
       minimum-approvals:
         required: false
@@ -168,7 +172,7 @@ jobs:
 
   terraform-plan:
     name: "⚙️ Terraform Init + Validate + Plan"
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.target_environment }}
 
     steps:
@@ -305,7 +309,7 @@ jobs:
     name: "${{ inputs.destroy && '🔥 Terraform Destroy' || '🚀 Terraform Apply' }}"
     needs: terraform-plan
     if: ${{ !inputs.plan_only }}
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.target_environment }}
 
     steps:


### PR DESCRIPTION
Both jobs hardcode `runs-on: ubuntu-latest`, so a caller whose Terraform has to reach a **private endpoint cannot use this workflow at all**.

## The failure

A root that talks to a private EKS (or AKS) API server fails during plan, regardless of credentials:

```
Error: Get "https://XXXX.sk1.us-east-1.eks.amazonaws.com/apis/scheduling.k8s.io/v1/priorityclasses/...":
       dial tcp 10.30.11.24:443: i/o timeout
```

A GitHub-hosted runner has no route into the VPC. Nothing the caller can configure changes that — there is no combination of inputs that makes it work today.

It is not a rare corner either. The affected root is typically the one holding cluster addons, NodePools and Helm releases, so it fails on **every pull request that touches a shared module**, and the check goes permanently red. A check that can never pass is worse than no check: it trains reviewers to ignore red.

## The change

One optional input, defaulting to the current value:

```yaml
runner:
  required: false
  type: string
  default: ubuntu-latest
```

Applied to `terraform-plan` and `terraform-apply`.

**Nothing changes for any existing caller.** A caller with runners inside the VPC — ARC in the cluster, or any self-hosted label — sets:

```yaml
with:
  runner: arc-runners
```

## Why not the alternatives

**Make the endpoint public with a CIDR allowlist.** GitHub's hosted runner ranges are enormous and shared with every other customer, so this trades a real network boundary for CI convenience, permanently.

**Tunnel from the hosted runner.** Needs either a long-lived credential or an SSM session opened from outside the VPC, plus a HAProxy/socat layer in the job. More moving parts, and the credential is exactly what OIDC exists to remove.

**Let callers skip that root in CI.** Gives up the check entirely, which is what the affected caller is doing today.

Running the job where the resources already live is the smaller change.

## Verification

The file parses, the two jobs resolve to `${{ inputs.runner }}`, and the input defaults to `ubuntu-latest`. Callers pinning an existing tag are unaffected until they move to a tag containing this.

Worth confirming on your side whether this needs a matching entry in the workflow's README/docs table, and which tag you want it released under — the caller I have in mind pins an exact semver.
