### PR TITLE
Register binfmt when smurf-docker builds for a non-native platform

### DIFF
--- a/.github/workflows/smurf-docker.yml
+++ b/.github/workflows/smurf-docker.yml
@@ -53,6 +53,13 @@ on:
         description: Docker Image Build Platform
         type: string
         default: linux/amd64
+      runs_on:
+        description: Runner for the build job. Point this at an arm64 runner to
+          build arm64 images natively instead of under emulation, which is
+          several times faster.
+        type: string
+        required: false
+        default: ubuntu-latest
       docker_buildkit_enable:
         description: Set true to enable docker buildkit
         type: string
@@ -137,7 +144,7 @@ jobs:
   ###############################################
   docker_build:
     if: inputs.docker_enable == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
     permissions:
       id-token: write
       contents: read
@@ -147,6 +154,21 @@ jobs:
 
       - name: ⚙️ Setup Smurf
         uses: clouddrove/smurf@v1.1.6
+
+      - name: 🧩 Register binfmt handlers for cross platform builds
+        # Without a binfmt handler the runner cannot execute binaries for
+        # another architecture, so `--platform linux/arm64` on an amd64 runner
+        # pulls the right base image and then dies on the first RUN with
+        # "exec format error". The build looks like a Dockerfile problem when
+        # it is really a missing emulator.
+        #
+        # Skipped only when the requested platform is exactly the runner's
+        # own, so a native build, which is the default and the common case,
+        # is unaffected. An exact comparison rather than a substring one:
+        # a multi platform value such as linux/amd64,linux/arm64 contains
+        # the native platform but still needs an emulator for the rest.
+        if: ${{ inputs.docker_build_platform != (runner.arch == 'X64' && 'linux/amd64' || 'linux/arm64') }}
+        uses: docker/setup-qemu-action@v4.2.0
 
       - name: 🐳 Docker Image Build
         if: inputs.docker_buildkit_enable != 'true'


### PR DESCRIPTION
`smurf-docker.yml` accepts `docker_build_platform` and passes it to the build, but nothing registers a binfmt handler. Asking for a platform the runner cannot execute therefore fails on the first `RUN`:

```
smurf sdkr build myimage:tag -f Dockerfile --platform linux/arm64
exec /bin/sh: exec format error
The command '/bin/sh -c python -m venv /opt/venv' returned a non-zero code: 255
```

The base image for the requested platform is pulled correctly and then cannot run. It presents as a Dockerfile problem rather than a missing emulator, which is what makes it expensive to diagnose. Anyone deploying to Graviton or other arm nodes from an amd64 runner hits this the moment they set the input.

Found it deploying an EKS service onto Graviton nodes: the workflow built happily as amd64, and the pods crash looped with `exec format error` at the other end. Setting `docker_build_platform: linux/arm64` then moved the same error into the build. We have worked around it locally with an inline `setup-qemu-action` plus `build-push-action`, but the workaround belongs here rather than in every repository that hits this.

## Changes

**`setup-qemu-action` before the build**, when the requested platform is not the runner's own.

The comparison is exact rather than a substring test:

```yaml
if: ${{ inputs.docker_build_platform != (runner.arch == 'X64' && 'linux/amd64' || 'linux/arm64') }}
```

A multi-platform value like `linux/amd64,linux/arm64` *contains* the native platform but still needs an emulator for the rest, so `contains()` would skip the step and fail on the non-native half.

A native build, which is the default and the common case, skips the step entirely and is unaffected.

**A `runs_on` input**, defaulted to `ubuntu-latest` so nothing changes for existing callers. Emulated builds are several times slower than native ones, so a caller with arm64 runners available should be able to use them rather than being pinned to an amd64 runner by this workflow.

Both changes are backwards compatible: with the defaults, an existing caller's behaviour is byte for byte what it is today.