### PR TITLE
fix(smurf-tf): disable the terraform wrapper so self-hosted runners work

### DIFF
--- a/.github/workflows/smurf-tf-workflow.yml
+++ b/.github/workflows/smurf-tf-workflow.yml
@@ -241,6 +241,19 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ inputs.terraform_version }}
+          ## The wrapper is a Node script that shims the terraform binary so a
+          ## step can read stdout/stderr as action outputs. Nothing here uses
+          ## those outputs: smurf shells out to terraform itself.
+          ##
+          ## It is actively harmful on a self-hosted runner. The actions-runner
+          ## image ships Node only for running JS actions (externals/node20) and
+          ## does not put it on PATH, so the shim fails with:
+          ##
+          ##   /usr/bin/env: 'node': No such file or directory
+          ##   Initialization failed: exit status 127
+          ##
+          ## which reads as a Terraform problem and is not one.
+          terraform_wrapper: false
 
       - name: ⚙️ Setup Smurf
         uses: clouddrove/smurf@master
@@ -378,6 +391,19 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ inputs.terraform_version }}
+          ## The wrapper is a Node script that shims the terraform binary so a
+          ## step can read stdout/stderr as action outputs. Nothing here uses
+          ## those outputs: smurf shells out to terraform itself.
+          ##
+          ## It is actively harmful on a self-hosted runner. The actions-runner
+          ## image ships Node only for running JS actions (externals/node20) and
+          ## does not put it on PATH, so the shim fails with:
+          ##
+          ##   /usr/bin/env: 'node': No such file or directory
+          ##   Initialization failed: exit status 127
+          ##
+          ## which reads as a Terraform problem and is not one.
+          terraform_wrapper: false
 
       - name: ⚙️ Setup Smurf
         uses: clouddrove/smurf@master


### PR DESCRIPTION
Follow-up to #427. That PR let a caller choose the runner; this makes the workflow actually work on one.

## The failure

First run of the platform root on in-cluster ARC runners, straight after #427:

```
ℹ Starting infrastructure initialization in ./_infra/.../staging/platform/
/usr/bin/env: 'node': No such file or directory
/usr/bin/env: 'node': No such file or directory
/usr/bin/env: 'node': No such file or directory
✖ Initialization failed: exit status 127
```

`hashicorp/setup-terraform` installs, by default, a **Node wrapper** in place of the terraform binary, so a step can read stdout/stderr back as action outputs.

The `actions/actions-runner` image ships Node only for running JS actions, at `externals/node20`, and does not put it on `PATH`. So the shim cannot start, and every terraform invocation fails with **exit 127** — which reads as a Terraform or credentials problem and is neither.

`ubuntu-latest` happens to have `node` on `PATH`, which is the only reason this has never surfaced.

## The fix

```yaml
- uses: hashicorp/setup-terraform@v4
  with:
    terraform_version: ${{ inputs.terraform_version }}
    terraform_wrapper: false
```

**Nothing in this workflow reads those outputs.** `smurf` shells out to terraform itself, so the wrapper is pure overhead even on a hosted runner — it is not a trade-off, just a default that costs something and buys nothing here.

Applied to both `terraform-plan` and `terraform-apply`, since either can run on a self-hosted runner now.

## Why it matters for #427

Without this, the `runs_on` input added in #427 works for exactly the runners that already had Node, which excludes the standard ARC image — the main reason a caller reaches for a self-hosted runner in the first place. The two changes together are what make a private-endpoint root plannable in CI.

## Verified

The failure above is from a real run (`arc-runners-cpct5-runner-mr4n6`), not a hypothetical. The runner selection from #427 worked correctly; this is the next thing that broke.

Happy to re-run the same dispatch once this is merged and report back.

## Possibly worth a follow-up

`smurf-helm-deploy.yml` pairs `runs_on` with a `devops_binary` toggle that installs AWS CLI, kubectl, Helm, Terraform, jq and yq, precisely because self-hosted runners lack the preinstalled tooling. This workflow has no equivalent, and mostly uses actions rather than bare CLIs, so it may not need one — but if other callers hit missing binaries beyond Node, that is the shape of the answer.

One further note for anyone else moving to self-hosted: the approval gate is a container action, so the runner needs Docker. `containerMode: dind` provides it.
