### PR TITLE
ci: skip commitlint for dependabot commits and bump terraform-validate to v3

### DIFF
--- a/.github/workflows/tf-workflow.yml
+++ b/.github/workflows/tf-workflow.yml
@@ -209,7 +209,7 @@ jobs:
       - name: 🔎 Terraform validate
         if: ${{ inputs.destroy != true }}
         id: validate
-        uses: dflook/terraform-validate@v2
+        uses: dflook/terraform-validate@v3
         with:
           path: ${{ inputs.working_directory }}
 

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,5 +1,9 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  // Dependabot writes a multi-line body (release notes, compare links, the
+  // updated-dependencies block) that we do not control and that always trips
+  // body-max-line-length. Skip linting for its commits entirely.
+  ignores: [(message) => message.includes('Signed-off-by: dependabot[bot]')],
   rules: {
     'type-enum': [2, 'always', [
       'fix', 'feat', 'docs', 'ci', 'chore', 'test', 'refactor', 'style', 'perf', 'build', 'revert',


### PR DESCRIPTION
## What

Two small CI fixes.

**1. Skip commitlint on dependabot commits**

Every dependabot PR fails `🧾 Validate Commit Messages` with:

```
✖   body's lines must not be longer than 100 characters [body-max-line-length]
```

The offending lines are release notes, compare links and the
`updated-dependencies` block that dependabot generates itself. They cannot be
reformatted from our side, so the check has been failing on every dependency
bump (#404, #421, #432).

`commitlint.config.cjs` now ignores commits carrying the
`Signed-off-by: dependabot[bot]` trailer. Human-authored commits are still
linted exactly as before.

**2. Bump `dflook/terraform-validate` to v3**

`tf-workflow.yml` pins three actions from `dflook/terraform-github-actions`,
which are released as one version. Dependabot opened bumps for `fmt-check`
(#430) and `plan` (#431) but not `validate`, which would leave the workflow on
a mix of v2 and v3. This keeps all three in step.

v3.0.0 has no breaking API change: the container base moved from debian 12 to
13, output names gained `_` aliases alongside `-`, and several PR-comment
formatting bugs were fixed.

## Verification

Config loads and the predicate matches the intended commits only:

```
config loads OK
dependabot ignored: true
human ignored: false
```