### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/aws-prowler.yml
+++ b/.github/workflows/aws-prowler.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🐍 Install pip
         run: |
@@ -103,7 +103,7 @@ jobs:
 
       - name: ☁️ Install AWS CLI
         if: ${{ inputs.cloud_provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: 📤 Upload Artifact
         if: ${{ inputs.enable_s3_upload == false }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: prowler-reports
           path: /home/runner/work/prowler/prowler/output/
@@ -149,7 +149,7 @@ jobs:
           aws s3 cp /home/runner/work/prowler/prowler/output/ s3://${{ secrets.S3_BUCKET_NAME }}/$YEAR/$MONTH/ --recursive
 
       - name: 📣 Notify Slack
-        uses: clouddrove/action-slack-notify@1
+        uses: clouddrove/action-slack-notify@9a2ed5aec6f637eddc793a299d731c794957584e # 1.0.1
         if: ${{ inputs.enable_slack_notification == true }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/aws-remote-ssh-command.yml
+++ b/.github/workflows/aws-remote-ssh-command.yml
@@ -83,10 +83,10 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔐 Executing remote SSH commands using SSH key
-        uses: appleboy/ssh-action@v1.2.5
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: 📣 Slack notification
         if: ${{ inputs.slack-notification == 'true' && always() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_MESSAGE: ${{ inputs.slack_message }}

--- a/.github/workflows/aws-ssm-send-command.yml
+++ b/.github/workflows/aws-ssm-send-command.yml
@@ -57,10 +57,10 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Execute Remote Command via AWS SSM
-        uses: peterkimzz/aws-ssm-send-command@master
+        uses: peterkimzz/aws-ssm-send-command@8d32fbc744c127490e85b29eefff09d40494fc86 # v1.1.1
         id: ssm
         with:
           aws-region: ${{ secrets.AWS_REGION }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Slack notification
         if: ${{ inputs.slack-notification == 'true' && always() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_MESSAGE: ${{ inputs.slack_message }}

--- a/.github/workflows/cf-deploy-stackset.yml
+++ b/.github/workflows/cf-deploy-stackset.yml
@@ -75,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔐 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID}}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -84,10 +84,10 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📥 Checkout code from another Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ inputs.organization-name }}/${{ inputs.GitHub-repo-name }}
           ref: ${{ inputs.GitHub-branch }}
@@ -95,7 +95,7 @@ jobs:
           path: ${{ inputs.GitHub-repo-name }}
 
       - name: 🔐 Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID}}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -111,7 +111,7 @@ jobs:
             aws s3 cp  ${{inputs.zip-file-name}} s3://${{ inputs.s3-bucket }}/${{ inputs.bucket-prefix }}/
 
       - name: 🚀 Deploy cloudformation stack using template
-        uses: aws-actions/aws-cloudformation-github-deploy@v2
+        uses: aws-actions/aws-cloudformation-github-deploy@81e3b03d2266bcb76c4bcc37a7d71d9cb67838bb # v2.2.0
         with:
           name: ${{ inputs.stack-name }}
           template: ${{ inputs.template-path }}
@@ -133,7 +133,7 @@ jobs:
         env:
           NAORU_KEY: ${{ secrets.NAORU_API_KEY }}
         if: ${{ env.NAORU_KEY != '' }}
-        uses: clouddrove/naoru@v0
+        uses: clouddrove/naoru@1fbf9f8977d855a35865c771679bb51f7474e397 # v0.2.3
         with:
           api-key: ${{ secrets.NAORU_API_KEY }}
           provider: openrouter

--- a/.github/workflows/cf-lint.yml
+++ b/.github/workflows/cf-lint.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🧪 cfn-lint-action
-        uses: ScottBrenner/cfn-lint-action@v2
+        uses: ScottBrenner/cfn-lint-action@be676baed6db1a0d44f2f3ea59554623dc5b4109 # v2.4.9
         with:
           command: cfn-lint -t ${{ inputs.cf_file_path }}
 
       - name: 🔒 cfn security checks
-        uses: minchao/cfn-nag-action@v0.1
+        uses: minchao/cfn-nag-action@7a57ff47a03f87c7ea82265d96423a4182fde35f # v0.1
         with:
           args: '--input-path ${{ inputs.cf_file_path }}'
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
 
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🧹 Run YAML Lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         continue-on-error: true
         with:
           file_or_dir: .github/workflows/
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔍 Validate Workflow Structure
         run: |
@@ -107,17 +107,17 @@ jobs:
       security-events: write
     steps:
       - name: 📦 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔒 Run TFSec Security Scan
-        uses: aquasecurity/tfsec-action@v1.0.3
+        uses: aquasecurity/tfsec-action@b466648d6e39e7c75324f25d83891162a721f2d6 # v1.0.3
         continue-on-error: true
         with:
           soft_fail: true
           working_directory: .github/workflows/
 
       - name: 🔒 Run Checkov Security Scan
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@5659ddea96102e16d8f221b3d8402453c0b1c150 # v12.3121.0
         continue-on-error: true
         with:
           directory: .github/workflows/
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📚 Check Documentation Links
         run: |
@@ -215,7 +215,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🏷️ Check Naming Conventions
         run: |
@@ -248,10 +248,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔍 Run Actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@dbe5299849118fd6f099ba563d263d770955a64a # v1.73.2
         continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -266,7 +266,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📝 Generate Workflow Index
         run: |
@@ -287,7 +287,7 @@ jobs:
           echo "✅ Workflow index generated"
 
       - name: 📤 Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workflow-index
           path: WORKFLOW_INDEX.md
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚠️ Check for Deprecated Actions
         run: |
@@ -326,7 +326,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔐 Check Workflow Permissions
         run: |
@@ -349,7 +349,7 @@ jobs:
     if: always()
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📊 CI Summary
         run: |
@@ -386,7 +386,7 @@ jobs:
         env:
           NAORU_KEY: ${{ secrets.NAORU_API_KEY }}
         if: ${{ env.NAORU_KEY != '' }}
-        uses: clouddrove/naoru@v0
+        uses: clouddrove/naoru@1fbf9f8977d855a35865c771679bb51f7474e397 # v0.2.3
         with:
           api-key: ${{ secrets.NAORU_API_KEY }}
           provider: openrouter

--- a/.github/workflows/cloudrun-rollback.yml
+++ b/.github/workflows/cloudrun-rollback.yml
@@ -45,12 +45,12 @@ jobs:
 
     steps:
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Get current revision
         id: prev

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -60,11 +60,11 @@ jobs:
     steps:
 
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔑 Login to Docker Hub
         if: ${{ inputs.provider == 'DOCKERHUB' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: 🔧 Configure AWS credentials
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -100,7 +100,7 @@ jobs:
       - name: 🔑 Login to Amazon ECR
         if: ${{ inputs.provider == 'aws' }}
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
 
       - name: 🚢 Push docker image to Amazon ECR
         if: ${{ inputs.provider == 'aws' }}
@@ -145,7 +145,7 @@ jobs:
         env:
           NAORU_KEY: ${{ secrets.NAORU_API_KEY }}
         if: ${{ env.NAORU_KEY != '' }}
-        uses: clouddrove/naoru@v0
+        uses: clouddrove/naoru@1fbf9f8977d855a35865c771679bb51f7474e397 # v0.2.3
         with:
           api-key: ${{ secrets.NAORU_API_KEY }}
           provider: openrouter

--- a/.github/workflows/docker-scanner.yml
+++ b/.github/workflows/docker-scanner.yml
@@ -29,17 +29,17 @@ jobs:
     steps:
 
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🛠️ Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: 🏗️ Build and export to Docker
         id: build-id
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: false
           load: true  #  Export to Docker Engine rather than pushing to a registry
@@ -48,7 +48,7 @@ jobs:
           file: ${{inputs.dockerfile-path}}
 
       - name: 🔍 Docker Scan with trivy (non-blocking)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           tags: ${{ github.sha }}
         with:
@@ -59,13 +59,13 @@ jobs:
 
       - name: ☁️ Upload Trivy scan results to GitHub Security tab
         if: ${{ inputs.security-upload == 'true' }}
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: 🚨 Docker Scan with trivy (blocking)
         if: ${{ inputs.block_action == true }}
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ github.sha }}
           format: table

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -50,16 +50,16 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Setup Docker buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           driver-opts: |
             image=moby/buildkit:v0.10.6
 
       - name: 🔐 Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -74,7 +74,7 @@ jobs:
 
       - name: 🕵️ Docker Scout
         id: docker-scout
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
         with:
           command: cves,recommendations,compare
           to-latest: false

--- a/.github/workflows/gcp-prowler.yml
+++ b/.github/workflows/gcp-prowler.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🐍 Install pip
         run: |
@@ -89,13 +89,13 @@ jobs:
 
       - name: 🔑 Authenticate with Google Cloud using GCP_KEY
         if: ${{ inputs.cloud_provider == 'gcp' && inputs.enable_gcp_key_auth == true }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCP_KEY }}
 
       - name: ☁️ Authenticate with Google Cloud using WIF
         if: ${{ inputs.cloud_provider == 'gcp' && inputs.enable_gcp_key_auth == false }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
           workload_identity_provider: ${{ secrets.WIP }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: 📤 Upload Artifact (If GCS Upload Disabled)
         if: ${{ inputs.enable_gcs_upload == false }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: prowler-reports
           path: ${{ github.workspace }}/report/
@@ -145,7 +145,7 @@ jobs:
           done
 
       - name: 📣 Notify Slack
-        uses: clouddrove/action-slack-notify@1
+        uses: clouddrove/action-slack-notify@9a2ed5aec6f637eddc793a299d731c794957584e # 1.0.1
         if: ${{ inputs.enable_slack_notification == true }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/helm-deploy.yml
+++ b/.github/workflows/helm-deploy.yml
@@ -117,11 +117,11 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔧 Configure AWS credentials
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azure' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -186,7 +186,7 @@ jobs:
 
       - name: 📤 Upload Diagram Artifact
         if: ${{ inputs.generate-diagram == true }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: helm-diagram
           path: ${{ inputs.diagram-file-name }}
@@ -241,7 +241,7 @@ jobs:
         env:
           NAORU_KEY: ${{ secrets.NAORU_API_KEY }}
         if: ${{ env.NAORU_KEY != '' }}
-        uses: clouddrove/naoru@v0
+        uses: clouddrove/naoru@1fbf9f8977d855a35865c771679bb51f7474e397 # v0.2.3
         with:
           api-key: ${{ secrets.NAORU_API_KEY }}
           provider: openrouter

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛠️ Setup Infracost
-        uses: infracost/actions/setup@fb736a8f219195d6efdca58682069b16fe1bc280
+        uses: infracost/actions/setup@fb736a8f219195d6efdca58682069b16fe1bc280 # v4.2.0
         with:
           api-key: ${{ secrets.INFRACOST_API_KEY }}
 
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
@@ -51,7 +51,7 @@ jobs:
                               --out-file=/tmp/infracost-base.json
 
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔀 Generate Infracost diff
         run: |
@@ -70,7 +70,7 @@ jobs:
           infracost output --path /tmp/infracost.json --show-skipped --format html --out-file report.html
 
       - name: 📤 Upload current cost in artifactory
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: report.html
           path: ${{ inputs.working-directory }}/report.html
@@ -96,7 +96,7 @@ jobs:
           echo "diffTotalMonthlyCost=$(jq '(.diffTotalMonthlyCost // 0) | tonumber' /tmp/infracost.json)" >> "$GITHUB_OUTPUT"
 
       - name: 🚀 Send cost estimate to Slack
-        uses: slackapi/slack-github-action@v4
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         if: ${{ inputs.slack_notification == 'true' }}
         with:
           payload: ${{ steps.infracost-slack.outputs.slack-message }}

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -187,7 +187,7 @@ jobs:
           echo "payload=$(jq -c . payload.json)" >> $GITHUB_OUTPUT
 
       - name: Send to Slack
-        uses: slackapi/slack-github-action@v4
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.postMessage
           payload: ${{ steps.build.outputs.payload }}

--- a/.github/workflows/pr-auto-assignee.yml
+++ b/.github/workflows/pr-auto-assignee.yml
@@ -26,14 +26,14 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
-      - uses: wow-actions/auto-assign@v3
+      - uses: wow-actions/auto-assign@67fafa03df61d7e5f201734a2fa60d1ab111880d # v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB }}
           assignees: ${{ inputs.assignees }}
           reviewers: ${{ inputs.reviewers }}
           skipKeywords: wip, draft
 
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: ${{ inputs.assign_yourself }}
         with:
           github-token: ${{ secrets.GITHUB }}

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
 
       - name: Wait for "${{ matrix.tf-checks }}" to Succeed
-        uses: lewagon/wait-on-check-action@v1.8.0
+        uses: lewagon/wait-on-check-action@96d9100b431964d10e0136aff8b9ccb92470505e # v1.8.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-name: ${{ matrix.tf-checks }}
@@ -65,7 +65,7 @@ jobs:
         shell: bash
 
       - name: Wait for "${{ matrix.tf-checks }}" to Succeed
-        uses: lewagon/wait-on-check-action@v1.8.0
+        uses: lewagon/wait-on-check-action@96d9100b431964d10e0136aff8b9ccb92470505e # v1.8.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-name: ${{ matrix.tf-checks }}
@@ -133,7 +133,7 @@ jobs:
       inputs.azure_cloud == true
     steps:
       - name: Automerge
-        uses: pascalgn/automerge-action@v0.16.4
+        uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB }}
           MERGE_FILTER_AUTHOR: 'dependabot[bot]'
@@ -151,7 +151,7 @@ jobs:
       github.event.pull_request.draft == false && !inputs.azure_cloud
     steps:
       - name: Automerge
-        uses: pascalgn/automerge-action@v0.16.4
+        uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB }}
           MERGE_FILTER_AUTHOR: 'dependabot[bot]'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: 🧾 Commitlint Validation
-        uses: wagoid/commitlint-github-action@v6
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: ${{ inputs.commitlintConfig }}
 ...

--- a/.github/workflows/pr-claude-review.yml
+++ b/.github/workflows/pr-claude-review.yml
@@ -24,18 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
   # Claude AI feedback
   claude:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
       - name: Automatic PR Review
-        uses: anthropics/claude-code-action@v1.0.198
+        uses: anthropics/claude-code-action@3f854a8fb5146b39d5cbf8b57f70d80810e1366f # v1.0.198
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/pr-gemini-review.yml
+++ b/.github/workflows/pr-gemini-review.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔍 Get PR diff
         id: diff
@@ -46,7 +46,7 @@ jobs:
 
       - name: 🤖 Run Gemini Review
         id: gemini
-        uses: google-github-actions/run-gemini-cli@v0.1.22
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_model: "gemini-2.5-pro"
@@ -56,7 +56,7 @@ jobs:
 
       - name: 💬 Comment Review on PR
         if: steps.gemini.outputs.summary != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-gitleaks-scan.yml
+++ b/.github/workflows/pr-gitleaks-scan.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.ref }}
 
       - name: 🔐 Run gitleaks on PR changes
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/pr-lock.yml
+++ b/.github/workflows/pr-lock.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🔒 Lock issues, PRs & discussions
-        uses: dessant/lock-threads@v6
+        uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: ${{ secrets.github-token }}
           issue-comment: >

--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🤖 Run Stale Action
-        uses: actions/stale@v11
+        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: ${{ inputs.days-before-issue-stale }}

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -15,38 +15,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
       - name: 🐍 Set up Python 3.7
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
 
       - name: 📝 Create readme
-        uses: 'clouddrove/github-actions@v9.0.4'
+        uses: clouddrove/github-actions@8782c8d7d3c8e4c0cbca6eded77f36f284c2dc78 # v9.0.4
         with:
           actions_subcommand: 'readme'
           github_token: ${{ secrets.TOKEN }}
 
       - name: ✅ Pre-commit check errors
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         continue-on-error: true
 
       - name: 🛠️ Pre-commit fix errors
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         continue-on-error: true
 
       - name: 🚀 Push readme
-        uses: 'clouddrove/github-actions@v9.0.4'
+        uses: clouddrove/github-actions@8782c8d7d3c8e4c0cbca6eded77f36f284c2dc78 # v9.0.4
         with:
           actions_subcommand: 'push'
           github_token: ${{ secrets.TOKEN }}
 
       - name: 📣 Slack Notification
-        uses: clouddrove/action-slack@v2
+        uses: clouddrove/action-slack@874218b8b8b4ffa08c76da3adfad30045de8ac9e # v2.5.0
         with:
           status: ${{ job.status }}
           fields: repo,author

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -73,14 +73,14 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GITHUB }}
           ref: ${{ inputs.release_tag }}
 
       - name: 📝 Generate Changelog
         id: changelog
-        uses: requarks/changelog-action@v1
+        uses: requarks/changelog-action@b78a3354a01f4a1affb484b9264b506a815c46b1 # v1.10.3
         with:
           token: ${{ secrets.GITHUB }}
           tag: ${{ inputs.release_tag }}
@@ -92,7 +92,7 @@ jobs:
           reverseOrder: false
 
       - name: 🚀 Create Release
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           token: ${{ secrets.GITHUB }}
           tag: ${{ inputs.release_tag }}
@@ -103,7 +103,7 @@ jobs:
           body: ${{ steps.changelog.outputs.changes }}
 
       - name: 💾 Commit CHANGELOG.md
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           branch: ${{ inputs.branch }}
           commit_user_name: clouddrove-ci

--- a/.github/workflows/release-maintain-major-tag.yml
+++ b/.github/workflows/release-maintain-major-tag.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB }}

--- a/.github/workflows/security-checkov.yml
+++ b/.github/workflows/security-checkov.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🧹 Cleanup Old SARIF
         run: rm -f results.sarif || true
@@ -47,7 +47,7 @@ jobs:
       - name: 🛡️ Run Checkov (Docker-based)
         id: checkov
         continue-on-error: true
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@5659ddea96102e16d8f221b3d8402453c0b1c150 # v12.3121.0
         with:
           directory: ${{ inputs.directory }}
           framework: terraform
@@ -60,14 +60,14 @@ jobs:
 
       - name: 📤 Upload SARIF to GitHub Security
         if: always() && !cancelled()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif
           category: checkov
 
       - name: 💬 Comment on PR with Checkov results
         if: github.event_name == 'pull_request'
-        uses: clouddrove/checkov-sarif-view@v0.0.1
+        uses: clouddrove/checkov-sarif-view@63254cbfe07b670c4ede0a012df60090c1af6d8a # v0.0.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           sarif_file: results.sarif

--- a/.github/workflows/security-powerpipe.yml
+++ b/.github/workflows/security-powerpipe.yml
@@ -92,10 +92,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔑 Setup AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.aws_assume_role }}
           role-session-name: powerpipe
@@ -103,7 +103,7 @@ jobs:
         if: ${{ inputs.cloud_provider == 'AWS' }}
 
       - name: ☁️ Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -115,7 +115,7 @@ jobs:
         if: ${{ inputs.cloud_provider == 'GCP' }}
 
       - name: 🔷 Authenticate to Azure Cloud
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -123,19 +123,19 @@ jobs:
         if: ${{ inputs.cloud_provider == 'AZURE' }}
 
       - name: 🧩 Setup Steampipe
-        uses: turbot/steampipe-action-setup@v1
+        uses: turbot/steampipe-action-setup@ea334bd03cc89b940db6b2daec94d0e0eab47dc0 # v1.7.0
         with:
           plugin-connections: ${{ inputs.plugin_connection }}
 
       - name: ⚡ Install Powerpipe
-        uses: turbot/powerpipe-action-setup@v1
+        uses: turbot/powerpipe-action-setup@458766075e63ffeb1992e6109759526f68611708 # v1.0.0
 
       - name: ▶️ Start steampipe service
         run: |
           steampipe service start
 
       - name: 🛡️ Run Terraform AWS Compliance control
-        uses: turbot/powerpipe-action-check@v1
+        uses: turbot/powerpipe-action-check@0b905d17e8b6970bc39bcd347c053992bd8770de # v1.0.1
         with:
           mod-url: ${{ inputs.mod_url }}
           controls: ${{ inputs.controls }}
@@ -153,7 +153,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: 💬 Comment on the PR with the markdown report
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/security-prowler.yml
+++ b/.github/workflows/security-prowler.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🍺 Install Homebrew
         run: |
@@ -74,7 +74,7 @@ jobs:
 
       - name: ☁️ Authenticate with Google Cloud
         if: ${{ inputs.cloud_provider == 'gcp' }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
           workload_identity_provider: ${{ secrets.WIP }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: ☁️ Install AWS CLI
         if: ${{ inputs.cloud_provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -121,7 +121,7 @@ jobs:
         continue-on-error: true
 
       - name: 📤 Upload report directory
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: compliance-report
           path: ${{ github.workspace }}/report/

--- a/.github/workflows/security-tfsec.yml
+++ b/.github/workflows/security-tfsec.yml
@@ -20,30 +20,30 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@master
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔍 Run tfsec
-        uses: aquasecurity/tfsec-sarif-action@v0.1.4
+        uses: aquasecurity/tfsec-sarif-action@21ded20e8ca120cd9d3d6ab04ef746477542a608 # v0.1.4
         with:
           sarif_file: tfsec.sarif
           working_directory: ${{ inputs.working_directory}}
           full_repo_scan: true
 
       - name: 📤 Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif
         continue-on-error: true
 
       - name: 💬 tfsec commenter for PR
-        uses: tfsec/tfsec-pr-commenter-action@v1.3.1
+        uses: tfsec/tfsec-pr-commenter-action@7a44c5dcde5dfab737363e391800629e27b6376b # v1.3.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB}}
           working_directory: ${{ inputs.working_directory}}
 
       - name: 🔒 Terraform security scan Advanced
-        uses: triat/terraform-security-scan@v3.2.0
+        uses: triat/terraform-security-scan@33b3376e624404b08b2e8725a8147339bdf6c358 # v3.2.0
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB}}

--- a/.github/workflows/smurf-docker.yml
+++ b/.github/workflows/smurf-docker.yml
@@ -150,10 +150,10 @@ jobs:
       contents: read
     steps:
       - name: 📦 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Setup Smurf
-        uses: clouddrove/smurf@v1.1.6
+        uses: clouddrove/smurf@bcbebeb0d9ac2747befbe40c3b685a30dd48f1e6 # v1.1.6
 
       - name: 🧩 Register binfmt handlers for cross platform builds
         # Without a binfmt handler the runner cannot execute binaries for
@@ -168,7 +168,7 @@ jobs:
         # a multi platform value such as linux/amd64,linux/arm64 contains
         # the native platform but still needs an emulator for the rest.
         if: ${{ inputs.docker_build_platform != (runner.arch == 'X64' && 'linux/amd64' || 'linux/arm64') }}
-        uses: docker/setup-qemu-action@v4.2.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: 🐳 Docker Image Build
         if: inputs.docker_buildkit_enable != 'true'
@@ -193,7 +193,7 @@ jobs:
             -o ${{ inputs.docker_image_tar }}
 
       - name: 📤 Upload Docker Image Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docker-image
           path: ${{ inputs.docker_image_tar }}
@@ -210,13 +210,13 @@ jobs:
       contents: read
     steps:
       - name: 📦 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Setup Smurf
-        uses: clouddrove/smurf@v1.1.6
+        uses: clouddrove/smurf@bcbebeb0d9ac2747befbe40c3b685a30dd48f1e6 # v1.1.6
 
       - name: 📥 Download Docker Image Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docker-image
 
@@ -226,7 +226,7 @@ jobs:
       # ── Cloud authentication ─────────────────────────────────────────
       - name: 🟦 Install AWS CLI
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -238,7 +238,7 @@ jobs:
 
       - name: 🔑 Assume another IAM role (Role Chaining)
         if: ${{ inputs.provider == 'aws' && inputs.aws_assume_role }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.aws_assume_role_arn }}
@@ -247,7 +247,7 @@ jobs:
 
       - name: ☁️ Authenticate Google Cloud with WIP and Service Account
         if: inputs.gcp_auth_method == 'wip'
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
           workload_identity_provider: ${{ secrets.GCP_WIP }}
@@ -257,7 +257,7 @@ jobs:
 
       - name: ☁️ Authenticate Google Cloud with Service Account JSON Key
         if: inputs.gcp_auth_method == 'json'
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 

--- a/.github/workflows/smurf-helm-deploy.yml
+++ b/.github/workflows/smurf-helm-deploy.yml
@@ -189,10 +189,10 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     steps:
       - name: 📦 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ⚙️ Setup Smurf
-        uses: clouddrove/smurf@v1.1.6
+        uses: clouddrove/smurf@bcbebeb0d9ac2747befbe40c3b685a30dd48f1e6 # v1.1.6
         with:
           version: ${{ inputs.smurf_version }}
 
@@ -227,7 +227,7 @@ jobs:
     environment: ${{ inputs.target_environment }}
     steps:
       - name: 📦 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🧰 Install DevOps Binaries
         if: ${{ inputs.devops_binary == 'install' }}
@@ -380,14 +380,14 @@ jobs:
           echo "---"
 
       - name: ⚙️ Setup Smurf
-        uses: clouddrove/smurf@v1.1.6
+        uses: clouddrove/smurf@bcbebeb0d9ac2747befbe40c3b685a30dd48f1e6 # v1.1.6
         with:
           version: ${{ inputs.smurf_version }}
 
       # ── Cloud authentication ─────────────────────────────────────────
       - name: 🟦 Configure AWS credentials
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -399,7 +399,7 @@ jobs:
 
       - name: 🔑 Assume another IAM role (Role Chaining)
         if: ${{ inputs.provider == 'aws' && inputs.aws_assume_role }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.aws_assume_role_arn }}
@@ -408,7 +408,7 @@ jobs:
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
@@ -417,7 +417,7 @@ jobs:
 
       - name: 🛠️ Set up gcloud SDK
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           project_id: ${{ inputs.gcp_project_id }}
           install_components: gke-gcloud-auth-plugin
@@ -432,7 +432,7 @@ jobs:
 
       - name: 🔵 Login to Azure
         if: ${{ inputs.provider == 'azure' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -478,7 +478,7 @@ jobs:
     environment: ${{ inputs.target_environment }}
     steps:
       - name: 📦 Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🧰 Install DevOps Binaries
         if: ${{ inputs.devops_binary == 'install' }}
@@ -631,14 +631,14 @@ jobs:
           echo "---"
 
       - name: ⚙️ Setup Smurf
-        uses: clouddrove/smurf@v1.1.6
+        uses: clouddrove/smurf@bcbebeb0d9ac2747befbe40c3b685a30dd48f1e6 # v1.1.6
         with:
           version: ${{ inputs.smurf_version }}
 
       # ── Cloud authentication ─────────────────────────────────────────
       - name: 🟦 Configure AWS credentials
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -650,7 +650,7 @@ jobs:
 
       - name: 🔑 Assume another IAM role (Role Chaining)
         if: ${{ inputs.provider == 'aws' && inputs.aws_assume_role }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.aws_assume_role_arn }}
@@ -659,7 +659,7 @@ jobs:
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
@@ -668,7 +668,7 @@ jobs:
 
       - name: 🛠️ Set up gcloud SDK
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           project_id: ${{ inputs.gcp_project_id }}
           install_components: gke-gcloud-auth-plugin
@@ -683,7 +683,7 @@ jobs:
 
       - name: 🔵 Login to Azure
         if: ${{ inputs.provider == 'azure' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/smurf-tf-checks.yml
+++ b/.github/workflows/smurf-tf-checks.yml
@@ -92,12 +92,12 @@ jobs:
     steps:
       # - Checkout the repository to the GitHub Actions runner
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # - Checking terraform Max and Min version.
       - name: 🧮 Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@main
+        uses: clowdhaus/terraform-min-max@5e40f8cf535d84fbd031571abd363ffd81dbfbfc # v3.0.1
 
   # - Evaluating terraform version based on version extract
   versionEvaluate:
@@ -116,11 +116,11 @@ jobs:
     steps:
       # - Checkout the repository to the GitHub Actions runner
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: ☁️ Install AWS CLI
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -132,13 +132,13 @@ jobs:
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: 'google-github-actions/auth@v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -150,13 +150,13 @@ jobs:
 
       # - Installing terraform version based on version extract.
       - name: 🛠️ Install Terraform v${{ inputs.terraform_version || needs.versionExtract.outputs.maxVersion }}
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ inputs.terraform_version || needs.versionExtract.outputs.maxVersion }}
 
       # - Setup smurf CLI
       - name: Setup Smurf
-        uses: clouddrove/smurf@v1.1.3
+        uses: clouddrove/smurf@383ad37fccbf97f740340354e6d7a5d7cf7dbaab # v1.1.3
 
       # - Terraform checks to Init and Validate terraform code.
       - name: 🏗️ Init & validate v${{ matrix.version }}
@@ -174,17 +174,17 @@ jobs:
     steps:
       # - Checkout the repository to the GitHub Actions runner
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # - Action added to install terraform
       - name: 🛠️ Install Terraform v${{ inputs.terraform_version || needs.versionExtract.outputs.maxVersion }}
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ inputs.terraform_version || needs.versionExtract.outputs.maxVersion }}
 
       # - Setup smurf
       - name: Setup Smurf
-        uses: clouddrove/smurf@v1.1.3
+        uses: clouddrove/smurf@383ad37fccbf97f740340354e6d7a5d7cf7dbaab # v1.1.3
 
       # - Running command to check terraform formatting changes.
       - name: 🧹 Check Terraform format changes

--- a/.github/workflows/smurf-tf-drift.yml
+++ b/.github/workflows/smurf-tf-drift.yml
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: 🌱 Set environment variables
         env:
@@ -113,7 +113,7 @@ jobs:
 
       - name: 🟦 Configure AWS credentials
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -136,13 +136,13 @@ jobs:
           project_id: ${{ inputs.project_id }}
 
       - name: 🛠️ Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false
 
       - name: ⚙️ Set up Smurf
-        uses: clouddrove/smurf@v1.1.6
+        uses: clouddrove/smurf@bcbebeb0d9ac2747befbe40c3b685a30dd48f1e6 # v1.1.6
         with:
           version: ${{ inputs.smurf_version }}
 
@@ -195,7 +195,7 @@ jobs:
 
       - name: 💾 Upload plan artifact
         if: steps.tf-plan.outputs.exitcode == '2' || steps.tf-plan.outputs.exitcode == '3'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smurf-tfplan-${{ github.run_id }}
           path: ${{ inputs.terraform_directory }}/${{ inputs.plan_out }}
@@ -236,7 +236,7 @@ jobs:
 
       - name: 🚨 Create or update drift issue
         if: inputs.create_issue && steps.tf-plan.outputs.exitcode == '2'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
           ISSUE_TITLE: ${{ inputs.drift_issue_title }}
@@ -276,7 +276,7 @@ jobs:
 
       - name: ✅ Close drift issue when clean
         if: inputs.close_issue_on_clean && steps.tf-plan.outputs.exitcode == '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ISSUE_TITLE: ${{ inputs.drift_issue_title }}
         with:

--- a/.github/workflows/smurf-tf-workflow.yml
+++ b/.github/workflows/smurf-tf-workflow.yml
@@ -178,9 +178,9 @@ jobs:
     steps:
 
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: webfactory/ssh-agent@v0.10.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         if: ${{ inputs.git_ssh_key_setup == true }}
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -199,7 +199,7 @@ jobs:
 
       - name: 🟦 Configure AWS
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -211,13 +211,13 @@ jobs:
 
       - name: ☁️ Azure Login
         if: ${{ inputs.provider == 'azurerm' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -229,7 +229,7 @@ jobs:
 
       - name: 🌊 Configure DigitalOcean
         if: ${{ inputs.provider == 'digitalocean' }}
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -238,7 +238,7 @@ jobs:
       ##########################
 
       - name: 🛠 Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ inputs.terraform_version }}
           ## The wrapper is a Node script that shims the terraform binary so a
@@ -256,7 +256,7 @@ jobs:
           terraform_wrapper: false
 
       - name: ⚙️ Setup Smurf
-        uses: clouddrove/smurf@master
+        uses: clouddrove/smurf@01c843ad06c0cd75f97a79e7e4b6463860f15ea5 # master@2026-08-26
         with:
           version: ${{ inputs.smurf_version }}
 
@@ -310,7 +310,7 @@ jobs:
       # and hand the wrong one to the wrong stage.
       - name: 📦 Upload plan
         if: ${{ !inputs.destroy }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.planid.outputs.name }}
           path: ${{ inputs.terraform_directory }}/tfplan
@@ -328,9 +328,9 @@ jobs:
     steps:
 
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: webfactory/ssh-agent@v0.10.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         if: ${{ inputs.git_ssh_key_setup == true }}
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -349,7 +349,7 @@ jobs:
 
       - name: 🟦 Configure AWS
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -361,13 +361,13 @@ jobs:
 
       - name: ☁️ Azure Login
         if: ${{ inputs.provider == 'azurerm' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -379,7 +379,7 @@ jobs:
 
       - name: 🌊 Configure DigitalOcean
         if: ${{ inputs.provider == 'digitalocean' }}
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -388,7 +388,7 @@ jobs:
       ##################################################
 
       - name: 🛠 Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ inputs.terraform_version }}
           ## The wrapper is a Node script that shims the terraform binary so a
@@ -406,7 +406,7 @@ jobs:
           terraform_wrapper: false
 
       - name: ⚙️ Setup Smurf
-        uses: clouddrove/smurf@master
+        uses: clouddrove/smurf@01c843ad06c0cd75f97a79e7e4b6463860f15ea5 # master@2026-08-26
         with:
           version: ${{ inputs.smurf_version }}
 
@@ -431,7 +431,7 @@ jobs:
       # someone has already approved.
       - name: 📥 Download plan
         if: ${{ !inputs.destroy }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ steps.planid.outputs.name }}
           path: ${{ inputs.terraform_directory }}
@@ -441,7 +441,7 @@ jobs:
       ##################################################
 
       - name: ⏳ Approval
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@fa642940caf8412403569b28b2db4a1df08a83a3 # v1.13.1
         timeout-minutes: ${{ inputs.timeout }}
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sst_workflow.yml
+++ b/.github/workflows/sst_workflow.yml
@@ -75,7 +75,7 @@ jobs:
     name: 🚀 Run sst-deploy
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 📝 Update environment variable in .env file
         run: |
@@ -84,7 +84,7 @@ jobs:
           fi
 
       - name: 🔑 Configure AWS Creds via role
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.build-role }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: 🧹 Cleanup preview env deployment
         if: ${{ ( github.event.action == 'labeled' && github.event.label.name == 'destroy' && inputs.preview == 'true' ) || (github.event.action == 'closed' && inputs.preview == 'true' || github.event.pull_request.merged == true && inputs.preview == 'true' ) }}
-        uses: strumwolf/delete-deployment-environment@v4.0.0
+        uses: strumwolf/delete-deployment-environment@035f6d27c8b8951729f4d71b2d3d6a7975139476 # v4.0.0
         with:
           token: ${{ secrets.token }}
           environment: ${{ github.head_ref }}

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
@@ -125,7 +125,7 @@ jobs:
 
       - name: 🧮 Get Terraform min/max versions
         id: minmax
-        uses: clowdhaus/terraform-min-max@main
+        uses: clowdhaus/terraform-min-max@5e40f8cf535d84fbd031571abd363ffd81dbfbfc # v3.0.1
 
       - name: 🎯 Set Terraform version
         id: set-version
@@ -141,7 +141,7 @@ jobs:
           fi
 
       - name: ♻️ Cache Terraform plugins
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: terraform-${{ runner.os }}-${{ hashFiles('**/.terraform.lock.hcl') }}
@@ -150,7 +150,7 @@ jobs:
 
       - name: ☁️ Install AWS CLI
         if: ${{ inputs.provider == 'aws' && inputs.enable_plan }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -162,19 +162,19 @@ jobs:
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' && inputs.enable_plan }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: ☁️ Install DigitalOcean CLI
         if: ${{ inputs.provider == 'digitalocean' }}
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' && inputs.enable_plan }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -185,7 +185,7 @@ jobs:
           project_id: ${{ inputs.project_id }}
 
       - name: 🛠️ Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
           terraform_version: ${{ steps.set-version.outputs.tf_version }}

--- a/.github/workflows/tf-diff-checks.yml
+++ b/.github/workflows/tf-diff-checks.yml
@@ -84,16 +84,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: ⚙️ Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: ☁️ Install AWS CLI
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -105,13 +105,13 @@ jobs:
 
       - name: 🔐 Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: 🔑 Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: 'google-github-actions/auth@v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -155,7 +155,7 @@ jobs:
         run: terraform show -no-color tfplan-target > plan-target.txt
 
       - name: 🧾 Generate Terraform Plan Diff
-        uses: int128/diff-action@v2
+        uses: int128/diff-action@4ea4f95e4684b2c719b963eefd7ff4b76d06ff8b # v2.36.0
         with:
           base: ${{ inputs.terraform_directory }}/plan-target.txt
           head: ${{ inputs.terraform_directory }}/plan-pr.txt

--- a/.github/workflows/tf-drift.yml
+++ b/.github/workflows/tf-drift.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔧 Set environment variables
         run: |
@@ -106,7 +106,7 @@ jobs:
 
       - name: ☁️ Install AWS CLI
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
@@ -119,7 +119,7 @@ jobs:
       # Authenticate to GCP
       - name: 🔐 Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: 'google-github-actions/auth@v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -132,12 +132,12 @@ jobs:
       # Install azure-cli
       - name: 🔧 Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: ⚙️ Set up Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ inputs.terraform_version }}
 
@@ -164,7 +164,7 @@ jobs:
 
       # Save plan to artifacts
       - name: 💾 Publish Terraform Plan
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfplan
           path: tfplan
@@ -197,7 +197,7 @@ jobs:
       # If changes are detected, create a new issue
       - name: 🚨 Publish Drift Report and create new issue
         if: steps.tf-plan.outputs.exitcode == 2
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
         with:
@@ -245,7 +245,7 @@ jobs:
       # If changes aren't detected, close any open drift issues
       - name: ✅ Publish Drift Report
         if: steps.tf-plan.outputs.exitcode == 0
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB }}
           script: |

--- a/.github/workflows/tf-lint.yml
+++ b/.github/workflows/tf-lint.yml
@@ -14,22 +14,22 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 💾 Cache plugin dir
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.tflint.d/plugins
           key: ubuntu-latest-tflint-${{ hashFiles('.tflint.hcl') }}
 
       - name: ⚙️ Setup TFLint
-        uses: terraform-linters/setup-tflint@v6
+        uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6.3.0
         with:
           tflint_version: v0.44.1
           github_token: ${{ secrets.GITHUB }}
 
       - name: 🛠️ Setup tflint-config
-        uses: terraform-linters/tflint-load-config-action@v3
+        uses: terraform-linters/tflint-load-config-action@32d9f74138340b95873e956fbdfc390db819bff1 # v3.0.0
         with:
           source-repo: clouddrove/github-shared-workflows
           source-path: .github/config/.tflint.hcl

--- a/.github/workflows/tf-monorepo-tag-release.yml
+++ b/.github/workflows/tf-monorepo-tag-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tf-terragrunt-drift.yml
+++ b/.github/workflows/tf-terragrunt-drift.yml
@@ -140,10 +140,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false
@@ -178,7 +178,7 @@ jobs:
 
       - name: 🟦 Configure AWS credentials
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -190,13 +190,13 @@ jobs:
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: 🔐 Authenticate to GCP
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -213,7 +213,7 @@ jobs:
 
       - name: Setup gcloud SDK
         if: ${{ inputs.provider == 'gcp' }}
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 

--- a/.github/workflows/tf-workflow.yml
+++ b/.github/workflows/tf-workflow.yml
@@ -137,9 +137,9 @@ jobs:
 
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: webfactory/ssh-agent@v0.10.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         if: ${{ inputs.git_ssh_key_setup == true }}
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: 🟦 Install AWS CLI
         if: ${{ inputs.provider == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -166,13 +166,13 @@ jobs:
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}
-        uses: azure/login@v3
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
-        uses: 'google-github-actions/auth@v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           create_credentials_file: ${{ inputs.create_credentials_file }}
@@ -184,19 +184,19 @@ jobs:
 
       - name: 🟦 Install doctl
         if: ${{ inputs.provider == 'digitalocean' }}
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: 🛠️ Set up Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ inputs.terraform_version }}
 
       - name: 🧹 Terraform Format
         if: ${{ inputs.destroy != true }}
         id: fmt
-        uses: 'dflook/terraform-fmt-check@v3'
+        uses: dflook/terraform-fmt-check@5702d43749973bd5b54e2380f090c1ad8054ecd4 # v3.0.0
         with:
           actions_subcommand: 'fmt'
           path: ${{ inputs.working_directory }}
@@ -209,7 +209,7 @@ jobs:
       - name: 🔎 Terraform validate
         if: ${{ inputs.destroy != true }}
         id: validate
-        uses: dflook/terraform-validate@v3
+        uses: dflook/terraform-validate@36ef08d500fe2cd9b742b10176d2683707c7074e # v3.0.0
         with:
           path: ${{ inputs.working_directory }}
 
@@ -217,7 +217,7 @@ jobs:
       - name: 📋 Terraform Plan
         if: ${{ inputs.target == '' && inputs.target_file == '' }}
         id: tf-plan
-        uses: dflook/terraform-plan@v3
+        uses: dflook/terraform-plan@3f1559b085c5ceff68c3724c9b66c015a6c940cd # v3.0.0
         with:
           path: ${{ inputs.working_directory }}
           var_file: ${{ inputs.var_file }}
@@ -265,7 +265,7 @@ jobs:
       # Upload plan artifact when using targeting
       - name: 📤 Publish Terraform Plan Artifact
         if: ${{ inputs.target != '' || inputs.target_file != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfplan
           path: ${{ inputs.working_directory }}/tfplan
@@ -320,7 +320,7 @@ jobs:
 
       - name: ✅ Accept plan or deny
         if: ${{ inputs.plan_only != true }}
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@fa642940caf8412403569b28b2db4a1df08a83a3 # v1.13.1
         timeout-minutes: ${{ inputs.timeout }}
         with:
           secret: ${{ github.TOKEN }}
@@ -371,7 +371,7 @@ jobs:
 
       - name: 📤 Upload Errored Terraform State Artifact
         if: ${{ always() && steps.find_errored_tfstate.outputs.errored_found == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: errored_tfstate
           path: ${{ inputs.working_directory }}/errored.tfstate
@@ -431,7 +431,7 @@ jobs:
         env:
           NAORU_KEY: ${{ secrets.NAORU_API_KEY }}
         if: ${{ env.NAORU_KEY != '' }}
-        uses: clouddrove/naoru@v0
+        uses: clouddrove/naoru@1fbf9f8977d855a35865c771679bb51f7474e397 # v0.2.3
         with:
           api-key: ${{ secrets.NAORU_API_KEY }}
           provider: openrouter

--- a/.github/workflows/yml-lint-internal.yml
+++ b/.github/workflows/yml-lint-internal.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔍 yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         continue-on-error: true
         with:
           file_or_dir: .github/workflows/

--- a/.github/workflows/yml-lint.yml
+++ b/.github/workflows/yml-lint.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📦 Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔍 yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         with:
           config_data: |
             rules:


### PR DESCRIPTION
Closes #433.

## What

Pins every external `uses:` reference in this repo to a full 40 character commit SHA, with the version kept in a trailing comment.

```diff
- uses: aws-actions/configure-aws-credentials@v6
+ uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
```

| | before | after |
|---|---|---|
| external `uses:` refs | 243 | 243 |
| pinned to a commit SHA | 2 | **243** |
| tracking a branch head | 6 | 0 |
| with a version comment | 0 | 243 |

46 of 50 workflows touched. The 6 remaining unpinned `uses:` lines are local `./.github/...` references, which resolve within this repo and carry no third party trust.

## Why

A tag is a movable pointer. `@v6` today and `@v6` tomorrow can be different code, and the move leaves no trace in any consumer's diff. That is exactly the mechanism behind the `tj-actions/changed-files` compromise (CVE-2025-30066, March 2025): the attacker retagged the existing version tags, and every consumer on a mutable tag ran the injected code, which dumped runner memory into public build logs. Anyone pinned to a SHA was unaffected and had nothing to do.

It matters more here than in an ordinary repo. These are reusable workflows. A consumer that pins *this* repo by SHA still inherits whatever these 241 tags point at today, so the pin they believe they have is not the pin they have.

Several of these jobs hold cloud credentials: `aws-actions/configure-aws-credentials` (22 call sites), `google-github-actions/auth` (13), `azure/login` (12).

## Behaviour

The sweep is behaviour preserving. Each tag was resolved to the commit it points at right now, so no action changes version and CI results should be identical. Three deliberate exceptions:

1. **Six refs tracked a branch head** and had no version at all. Five now point at the current release: `actions/checkout@master`, `aquasecurity/trivy-action@master`, `bridgecrewio/checkov-action@master`, `clowdhaus/terraform-min-max@main`, `peterkimzz/aws-ssm-send-command@master`.

2. **`bridgecrewio/checkov-action@master`** resolved to an older release (`v12.1347.0`) than the `@v12` already used elsewhere in this repo (`v12.3121.0`). Both call sites now share the `@v12` commit, which also removes one instance of version skew.

3. **`clouddrove/smurf@master`** is pinned to the current master commit rather than to a release. Master carries commits that `v1.1.9` does not, so moving to the tag would be a downgrade and could break these workflows. Worth revisiting once a release covers what they need.

## Verification

- All 50 workflows parse as YAML.
- `actionlint` before: 151 findings. After: **150**. None introduced.
- Every SHA was resolved through the GitHub API against the action's own repo, then cross checked against the tags pointing at that commit to derive the version comment.

## Two things worth knowing

**`actionlint` loses its action-specific checks on pinned refs.** It matches actions by `owner/repo@ref` against a known-actions list, so a SHA ref no longer matches. That is the single finding that disappeared: `ci.yml:259` uses a deprecated `fail_on_error` input on `reviewdog/action-actionlint`. The problem is still there, it is just no longer flagged. Small follow-up, happy to send it separately.

**SHA pinning is not total.** It freezes the action ref, not everything the action does at runtime. `aquasecurity/trivy-action` is a composite action that downloads the Trivy binary during the run, so its pin is partial. `dflook/*` pin their container by `sha256:` digest, so those are fully frozen. And pinning buys a reviewable moment at upgrade time, not immunity, since a Dependabot bump still means trusting new code.

## Not in this PR

Two items from #433 are deliberately left out, both because they change behaviour and want their own testing:

- **Version skew.** Several actions still run at different majors across workflows: `actions/checkout` (`v4`, `v6`, `v7`), `download-artifact` (`v4`, `v8`), `github-script` (`v7`, `v9`), `configure-aws-credentials` (`v4`, `v6`), `setup-terraform` (`v3`, `v4`), `clouddrove/smurf` (`v1.1.3`, `v1.1.6`, master).
- **A CI guard** (`actionlint` or `zizmor`) to stop new mutable refs from landing.