### PR TITLE
fix: declare workflow inputs and job refs that expressions read

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: 'us-east-1'
         type: string
+      role-to-assume:
+        description: 'ARN of the IAM role to assume. Leave empty to use the static access keys.'
+        required: false
+        default: ''
+        type: string
       stack-name:
         description: 'Stack name defined'
         required: true
@@ -101,7 +106,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ inputs.aws-region }}
-          role-to-assume: ${{ inputs.ROLE-TO-ASSUME }}
+          role-to-assume: ${{ inputs.role-to-assume }}
 
       - name: 📦 Src folder code convert into zip and upload to S3
         run: |

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -29,6 +29,11 @@ on:
       assume_role_arn:
         required: false
         type: string
+      role_duration_seconds:
+        description: 'Lifetime of the assumed role session, in seconds. Empty uses the action default.'
+        required: false
+        default: ''
+        type: string
     secrets:
       AWS_ACCESS_KEY_ID:
         required: false
@@ -86,9 +91,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          role-to-assume: ${{ secrets.BUILD_ROLE }}
+          role-to-assume: ${{ inputs.assume_role_arn || secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: ${{ inputs.role-duration-seconds }}
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
           role-skip-session-tagging: true
 
       - name: 🕵️ Verify awscli

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -83,7 +83,7 @@ jobs:
     if: |
       always() &&
       github.actor == 'dependabot[bot]' &&
-      (needs.static-checks.result == 'success' || needs.static-checks-azure.result == 'success')  && !inputs.azure_cloud
+      needs.static-checks.result == 'success' && !inputs.azure_cloud
     steps:
       - name: Approve PR via GitHub Bot
         run: gh pr review --approve "$PR_URL"
@@ -107,7 +107,7 @@ jobs:
     if: |
       always() &&
       github.actor == 'dependabot[bot]' &&
-      (needs.static-checks.result == 'success' || needs.static-checks-azure.result == 'success') &&
+      needs.static-checks-azure.result == 'success' &&
       inputs.azure_cloud == true
     steps:
       - name: Approve PR via GitHub Bot

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -13,6 +13,11 @@ on:
         default: 'vX.Y.Z'
         type: string
         description: "Repository tag format (e.g., vX.Y.Z or X.Y.Z)"
+      version_type:
+        description: 'Semver bump that produced this release (major, minor or patch). Display only.'
+        required: false
+        default: ''
+        type: string
       release_tag:
         required: true
         type: string

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -152,5 +152,6 @@ jobs:
       branch: ${{ inputs.target_branch }}
       tag_format: ${{ inputs.tag_format }}
       release_tag: ${{ needs.create-tag.outputs.final_tag }}
+      version_type: ${{ needs.create-tag.outputs.version_type }}
     secrets:
       GITHUB: ${{ secrets.GITHUB }}

--- a/.github/workflows/sst_workflow.yml
+++ b/.github/workflows/sst_workflow.yml
@@ -66,7 +66,7 @@ jobs:
     needs: [setup]
     runs-on: ${{ needs.setup.outputs.runner }}
     environment:
-      name: ${{ (((github.event.action == 'opened' || github.event.action == 'synchronize') && inputs.preview == 'true') || (github.event.pull_request.merged == true && inputs.preview == 'false' && inputs.app-env == 'staging') || (inputs.app-env == 'production' && startsWith(github.ref, 'refs/tags/v'))) && ((inputs.preview == 'true' && (inputs.stack-name != '' && github.head_ref-inputs.stack-name || github.head_ref) || inputs.app-env)) || '' }}
+      name: ${{ (((github.event.action == 'opened' || github.event.action == 'synchronize') && inputs.preview == 'true') || (github.event.pull_request.merged == true && inputs.preview == 'false' && inputs.app-env == 'staging') || (inputs.app-env == 'production' && startsWith(github.ref, 'refs/tags/v'))) && ((inputs.preview == 'true' && (inputs.stack-name != '' && inputs.stack-name || github.head_ref) || inputs.app-env)) || '' }}
       url: ${{ ((github.event.action == 'opened' && inputs.preview == 'true') || (github.event.action == 'synchronize' && inputs.preview == 'true') || (github.event.pull_request.merged == true && inputs.preview == 'false' && inputs.app-env == 'staging') || (inputs.app-env == 'production' && startsWith(github.ref, 'refs/tags/v'))) && env.API_ENDPOINT_URL }}
     defaults:
       run:

--- a/.github/workflows/tf-terragrunt-drift.yml
+++ b/.github/workflows/tf-terragrunt-drift.yml
@@ -37,6 +37,12 @@ on:
         type: boolean
         default: true
 
+      gcp_project_id:
+        description: "GCP project ID to authenticate against"
+        required: false
+        type: string
+        default: ""
+
       token_format:
         description: "GCP authentication token format"
         required: false
@@ -204,7 +210,7 @@ jobs:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
           access_token_lifetime: ${{ inputs.access_token_lifetime }}
-          project_id: ${{ inputs.GCP_PROJECT_ID }}
+          project_id: ${{ inputs.gcp_project_id }}
 
 
       ###############################################################


### PR DESCRIPTION
Closes #436.

## What

Seven expressions across six workflows referenced an input or job ID that was never declared. GitHub renders an undefined property as an empty string rather than failing, so each step ran with a blank value and the workflow reported success.

Every new input is optional with a default matching current behaviour, so no existing caller has to change. These workflows are consumed externally only, so nothing in this repo needed updating alongside them.

## The fixes

### 1. `cf-deploy.yml`: role assumption never happened

```diff
- role-to-assume: ${{ inputs.ROLE-TO-ASSUME }}
+ role-to-assume: ${{ inputs.role-to-assume }}
```

No `ROLE-TO-ASSUME` input existed, so `role-to-assume` was always empty and `configure-aws-credentials` silently skipped role assumption, falling back to the static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the same block. Anyone reading the workflow would reasonably believe deploys ran under an assumed role.

A `role-to-assume` input is now declared, defaulting to empty. Behaviour is unchanged until a caller passes it, but the capability now works.

### 2. `docker-build-push.yml`: undeclared input, plus a dead one

```diff
- role-to-assume: ${{ secrets.BUILD_ROLE }}
- role-duration-seconds: ${{ inputs.role-duration-seconds }}
+ role-to-assume: ${{ inputs.assume_role_arn || secrets.BUILD_ROLE }}
+ role-duration-seconds: ${{ inputs.role_duration_seconds }}
```

The file declares snake_case inputs, so the hyphenated `role-duration-seconds` was never going to resolve. Separately, the declared `assume_role_arn` input was referenced nowhere while the role came from `secrets.BUILD_ROLE`.

`role_duration_seconds` is now declared, and the role falls back to the secret only when the input is empty, which is exactly what happens today.

### 3. `tf-terragrunt-drift.yml`: GCP project never passed

```diff
- project_id: ${{ inputs.GCP_PROJECT_ID }}
+ project_id: ${{ inputs.gcp_project_id }}
```

`project_id` reached `google-github-actions/auth` empty, so authentication resolved whatever project the workload identity provider defaulted to rather than the intended one.

### 4. `sst_workflow.yml`: expression evaluated to NaN

```diff
- github.head_ref-inputs.stack-name || github.head_ref
+ inputs.stack-name || github.head_ref
```

`github.head_ref-inputs.stack-name` parses as `github.head_ref` **minus** `inputs.stack-name`: a subtraction of two strings, which evaluates to `NaN`. It sits on the `environment.name` line, so preview environments were named `NaN` whenever `preview == 'true'` and a stack name was set.

### 5 and 6. `pr-auto-merge.yml`: dead half of a condition

```diff
- (needs.static-checks.result == 'success' || needs.static-checks-azure.result == 'success')  && !inputs.azure_cloud
+ needs.static-checks.result == 'success' && !inputs.azure_cloud
```

Each job tested the other cloud's job without listing it in `needs`, and a job absent from `needs` is absent from the `needs` context, so that half was always false.

**No behaviour change.** The dead half was the wrong-cloud branch and the `azure_cloud` guard already selected the right job. This is a readability fix, and I have not dressed it up as more than that.

### 7. `release-changelog.yml`: empty value in the summary

`release-tag.yml` already computes `version_type` and exposes it as a job output. It simply never passed it through, so the release summary printed a blank. Now declared and wired. Display only.

## Verification

- All 50 workflows parse as YAML.
- `actionlint`: **150 findings before, 143 after.** Comparing with line numbers normalised, exactly these 7 are removed and **none** are introduced. The apparent additions in a raw diff are the same shellcheck notes shifted down by the new input blocks.
- `docker-build-push.yml` is CRLF; its line endings are preserved (9 changed lines, not a whole-file rewrite).

## Follow-up worth considering

`actionlint` already runs in CI and already caught all 7, it just reports `[expression]` below failing level. Promoting that one category to an error would stop this class recurring without drowning the job in the ~140 pre-existing shellcheck notes. Happy to send that separately if you want it.