### PR TITLE
feat(role-session-duration): make AWS role duration and session tagging configurable

### DIFF
--- a/.github/workflows/aws-prowler.yml
+++ b/.github/workflows/aws-prowler.yml
@@ -23,6 +23,11 @@ on:
         type: number
         default: 900
         description: 'Duration of the session.'
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       retention_days:
         required: false
         type: number
@@ -111,7 +116,7 @@ jobs:
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
           role-duration-seconds: ${{ inputs.role_duration_seconds }}
-          role-skip-session-tagging: true
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 🔎 Running Prowler for AWS
         env:

--- a/.github/workflows/cf-deploy-stackset.yml
+++ b/.github/workflows/cf-deploy-stackset.yml
@@ -8,6 +8,16 @@ on:
         required: false
         default: 'us-east-2'
         type: string
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       stackset-instance-region:
         description: 'Stackset-instance regions where you need cloudformation stacks'
         required: false
@@ -85,6 +95,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ inputs.aws-region }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 🔄 Check if StackSet exists or not-exist then create/update stack-set
         id: check-stackset

--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -22,6 +22,16 @@ on:
         required: false
         default: ''
         type: string
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       stack-name:
         description: 'Stack name defined'
         required: true
@@ -107,6 +117,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ inputs.aws-region }}
           role-to-assume: ${{ inputs.role-to-assume }}
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 📦 Src folder code convert into zip and upload to S3
         run: |

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -34,6 +34,11 @@ on:
         required: false
         default: ''
         type: string
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
     secrets:
       AWS_ACCESS_KEY_ID:
         required: false
@@ -94,7 +99,7 @@ jobs:
           role-to-assume: ${{ inputs.assume_role_arn || secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
           role-duration-seconds: ${{ inputs.role_duration_seconds }}
-          role-skip-session-tagging: true
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 🕵️ Verify awscli
         if: ${{ inputs.provider == 'aws' }}

--- a/.github/workflows/helm-deploy.yml
+++ b/.github/workflows/helm-deploy.yml
@@ -78,6 +78,11 @@ on:
         type: number
         default: 900
         description: 'The assumed role duration in seconds, if assuming a role. Defaults to 1 hour.'
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       diagram-file-name:
         required: false
         type: string
@@ -129,7 +134,7 @@ jobs:
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
-          role-skip-session-tagging: true
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azure' }}

--- a/.github/workflows/security-powerpipe.yml
+++ b/.github/workflows/security-powerpipe.yml
@@ -8,7 +8,6 @@ on:
         description: 'Cloud Provider Name. i.g. AWS, Azure, GCP, OCI'
         required: true
         type: string
-        default: 'AWS'
       mod_url:
         description: 'Powerpipe Mod URL. Get URL from here: https://hub.powerpipe.io/'
         required: false
@@ -53,6 +52,23 @@ on:
         required: false
         type: string
         description: 'ID of the default project to use for future API calls and invocations.'
+      
+      # AWS Authentication
+      aws_region:
+        required: false
+        type: string
+        default: us-east-2
+        description: 'AWS region of terraform deployment.'
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
 
     secrets:
       TOKEN:
@@ -63,6 +79,15 @@ on:
       aws_assume_role:
         description: 'AWS IAM role to assume. Necessary if cloud_provider is AWS.'
         required: false
+      AWS_ACCESS_KEY_ID:
+        required: false
+        description: 'AWS Access Key ID to install AWS CLI.'
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+        description: 'AWS Secret access key to install AWS CLI'
+      AWS_SESSION_TOKEN:
+        required: false
+        description: 'AWS Session Token to install AWS CLI'
 
       # Azure Authentication
       AZURE_CLIENT_ID:
@@ -95,12 +120,17 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 🔑 Setup AWS Credentials
+        if: ${{ inputs.cloud_provider == 'AWS' }}
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.aws_assume_role }}
           role-session-name: powerpipe
-          aws-region: us-east-1
-        if: ${{ inputs.cloud_provider == 'AWS' }}
+          aws-region: ${{ inputs.aws_region }}
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0

--- a/.github/workflows/security-prowler.yml
+++ b/.github/workflows/security-prowler.yml
@@ -26,6 +26,11 @@ on:
         type: number
         default: 900
         description: 'Duration of the session.'
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
 
     secrets:
       WIP:
@@ -92,7 +97,7 @@ jobs:
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
           role-duration-seconds: ${{ inputs.role_duration_seconds }}
-          role-skip-session-tagging: true
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 🔎 Run Prowler for GCP
         if: ${{ inputs.cloud_provider == 'gcp' }}

--- a/.github/workflows/smurf-docker.yml
+++ b/.github/workflows/smurf-docker.yml
@@ -81,6 +81,16 @@ on:
         type: string
         description: AWS assume role
         required: false
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
 
       # ── GCP ──────────────────────────────────────────────────────────
       gcp_project_id:
@@ -233,8 +243,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 🔑 Assume another IAM role (Role Chaining)
         if: ${{ inputs.provider == 'aws' && inputs.aws_assume_role }}
@@ -244,6 +254,8 @@ jobs:
           role-to-assume: ${{ inputs.aws_assume_role_arn }}
           role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
           role-chaining: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Authenticate Google Cloud with WIP and Service Account
         if: inputs.gcp_auth_method == 'wip'

--- a/.github/workflows/smurf-helm-deploy.yml
+++ b/.github/workflows/smurf-helm-deploy.yml
@@ -52,6 +52,16 @@ on:
         description: IAM role ARN to assume
         type: string
         required: false
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
 
       # ── GCP ──────────────────────────────────────────────────────────
       gcp_project_id:
@@ -394,8 +404,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 🔑 Assume another IAM role (Role Chaining)
         if: ${{ inputs.provider == 'aws' && inputs.aws_assume_role }}
@@ -405,6 +415,8 @@ jobs:
           role-to-assume: ${{ inputs.aws_assume_role_arn }}
           role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
           role-chaining: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}
@@ -645,8 +657,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 🔑 Assume another IAM role (Role Chaining)
         if: ${{ inputs.provider == 'aws' && inputs.aws_assume_role }}
@@ -656,6 +668,8 @@ jobs:
           role-to-assume: ${{ inputs.aws_assume_role_arn }}
           role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
           role-chaining: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}

--- a/.github/workflows/smurf-tf-checks.yml
+++ b/.github/workflows/smurf-tf-checks.yml
@@ -28,6 +28,11 @@ on:
         type: number
         default: 3600
         description: 'The assumed role duration in seconds, if assuming a role. Defaults to 1 hour (3600 seconds). Acceptable values range from 15 minutes (900 seconds) to 12 hours (43200 seconds).'
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       gcp_credentials:
         description: 'GCP credentials to use.'
         required: false
@@ -128,7 +133,7 @@ jobs:
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
           role-duration-seconds: ${{ inputs.role_duration_seconds }}
-          role-skip-session-tagging: true
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}

--- a/.github/workflows/smurf-tf-drift.yml
+++ b/.github/workflows/smurf-tf-drift.yml
@@ -17,6 +17,16 @@ on:
         type: string
         default: us-east-1
         description: 'AWS region for Terraform deployment.'
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       var_file:
         required: false
         type: string
@@ -120,8 +130,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Authenticate to Google Cloud
         if: ${{ inputs.provider == 'gcp' }}

--- a/.github/workflows/smurf-tf-workflow.yml
+++ b/.github/workflows/smurf-tf-workflow.yml
@@ -21,6 +21,18 @@ on:
         default: us-east-2
         description: AWS region where resources will be provisioned.
 
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
+
       gcp_region:
         required: false
         type: string
@@ -58,7 +70,7 @@ on:
         required: false
         type: number
         default: 10
-        description: Maximum timeout duration for the Terraform workflow execution.
+        description: Maximum number of minutes to wait for manual approval before the approval step times out.
 
       ## Named runs_on to match smurf-helm-deploy.yml, which already takes the
       ## same input with the same default. One concept, one name.
@@ -206,8 +218,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Azure Login
         if: ${{ inputs.provider == 'azurerm' }}
@@ -356,8 +368,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Azure Login
         if: ${{ inputs.provider == 'azurerm' }}

--- a/.github/workflows/sst_workflow.yml
+++ b/.github/workflows/sst_workflow.yml
@@ -35,6 +35,26 @@ on:
         description: 'Deploy stack with github self hosted runner or not'
         type: string
         default: true
+      provider:
+        required: false
+        type: string
+        default: aws
+        description: 'Cloud provider to run the workflow. e.g. azurerm, aws, gcp or digitalocean'
+      aws_region:
+        required: false
+        type: string
+        default: us-east-2
+        description: 'AWS region of terraform deployment.'
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
 
     secrets:
       token:
@@ -44,8 +64,17 @@ on:
         description: 'Environment-variables to store in .env file'
         required: false
       build-role:
-        description: 'Assume role arn'
-        required: true
+        required: false
+        description: 'AWS OIDC role for aws authentication.'
+      AWS_ACCESS_KEY_ID:
+        required: false
+        description: 'AWS Access Key ID to install AWS CLI.'
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+        description: 'AWS Secret access key to install AWS CLI'
+      AWS_SESSION_TOKEN:
+        required: false
+        description: 'AWS Session Token to install AWS CLI'
 
 jobs:
   setup:
@@ -83,13 +112,17 @@ jobs:
            echo -e "${{ secrets.env-vars }}" > ./.env
           fi
 
-      - name: 🔑 Configure AWS Creds via role
+      - name: 🟦 Install AWS CLI
+        if: ${{ inputs.provider == 'aws' }}
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          aws-region: us-west-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.build-role }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          aws-region: ${{ inputs.aws_region }}
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 📦 Install yarn
         run: sudo npm install -g yarn

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -33,6 +33,11 @@ on:
         type: number
         default: 3600
         description: 'The assumed role duration in seconds, if assuming a role. Defaults to 1 hour (3600 seconds). Acceptable values range from 15 minutes (900 seconds) to 12 hours (43200 seconds).'
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       enable_plan:
         required: false
         type: boolean
@@ -158,7 +163,7 @@ jobs:
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
           role-duration-seconds: ${{ inputs.role_duration_seconds }}
-          role-skip-session-tagging: true
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' && inputs.enable_plan }}

--- a/.github/workflows/tf-diff-checks.yml
+++ b/.github/workflows/tf-diff-checks.yml
@@ -22,6 +22,16 @@ on:
         type: string
         default: us-east-2
         description: 'AWS region of terraform deployment.'
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       gcp_region:
         required: false
         type: string
@@ -100,8 +110,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: 🔐 Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}

--- a/.github/workflows/tf-drift.yml
+++ b/.github/workflows/tf-drift.yml
@@ -18,6 +18,16 @@ on:
         type: string
         default: us-east-1
         description: 'AWS region of terraform deployment.'
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       var_file:
         required: false
         default: ""
@@ -113,8 +123,8 @@ jobs:
           aws-session-token: ${{ secrets.aws_session_token }}
           role-to-assume: ${{ secrets.build_role }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       # Authenticate to GCP
       - name: 🔐 Authenticate to Google Cloud

--- a/.github/workflows/tf-terragrunt-drift.yml
+++ b/.github/workflows/tf-terragrunt-drift.yml
@@ -66,6 +66,18 @@ on:
         type: string
         default: "eu-west-1"
 
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
+
     secrets:
       GCP_PROJECT_ID:
         description: "GCP Project ID"
@@ -191,8 +203,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}

--- a/.github/workflows/tf-workflow.yml
+++ b/.github/workflows/tf-workflow.yml
@@ -16,6 +16,16 @@ on:
         type: string
         default: us-east-2
         description: 'AWS region of terraform deployment.'
+      role_duration_seconds:
+        description: "The duration in seconds for the AWS IAM role session."
+        required: false
+        type: number
+        default: 3600
+      role_skip_session_tagging:
+        description: "Whether to skip adding session tags when assuming the AWS IAM role."
+        required: false
+        type: boolean
+        default: true
       gcp_region:
         required: false
         type: string
@@ -161,8 +171,8 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           role-to-assume: ${{ secrets.BUILD_ROLE }}
           aws-region: ${{ inputs.aws_region }}
-          role-duration-seconds: 900
-          role-skip-session-tagging: true
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
+          role-skip-session-tagging: ${{ inputs.role_skip_session_tagging }}
 
       - name: ☁️ Install Azure CLI
         if: ${{ inputs.provider == 'azurerm' }}


### PR DESCRIPTION
## Description
Make AWS role duration (`role-duration-seconds`) and session tagging (`role-skip-session-tagging`) configurable via workflow inputs.

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix
- [ ] ✨ New workflow
- [ ] 📝 Documentation update
- [x] 🔧 Workflow enhancement
- [ ] 🎨 Code style/formatting
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [ ] 🔒 Security improvement

## Workflow Category
<!-- If adding/modifying a workflow, select the category -->

- [x] Terraform (`tf-*`)
- [x] CloudFormation (`cf-*`)
- [x] Docker (`docker-*`)
- [x] Helm (`helm-*`)
- [ ] PR Automation (`pr-*`)
- [x] Security (`security-*`)
- [ ] Release (`release-*`)
- [ ] Notification (`notify-*`)
- [x] AWS-specific (`aws-*`)
- [ ] GCP-specific (`gcp-*`)
- [ ] YAML Lint (`yl-*`)
- [x] Smurf (`smurf-*`)
- [ ] Other

## Checklist
<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
<!-- Link related issues using #issue_number -->

Closes
- [smurf-tf-workflow: apply credentials expire during the approval wait, leaving orphaned resources and a stuck lock
](https://github.com/clouddrove/github-shared-workflows/issues/442)

